### PR TITLE
fix: require consecutive absences before purging dynamic entities

### DIFF
--- a/custom_components/unraid/cleanup.py
+++ b/custom_components/unraid/cleanup.py
@@ -39,6 +39,24 @@ if TYPE_CHECKING:
 _LOGGER = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
+# Transient-absence grace period
+# ---------------------------------------------------------------------------
+
+# Number of consecutive successful refreshes a dynamic resource may be absent
+# from the coordinator data before its entities are removed. The Unraid API
+# can transiently omit resources (UPS data in particular) from an otherwise
+# successful response; removing entities on the first gap deletes healthy
+# entities and breaks dashboards and automations until the integration is
+# reloaded (#293).
+_MISSING_STREAK_THRESHOLD: Final = 3
+
+# Consecutive-missing counters, keyed by unique_id. Bounded by the number of
+# dynamic entities across configured servers: entries are dropped when the
+# resource reappears, when the entity is removed, or when it is no longer
+# registered.
+_missing_streaks: dict[str, int] = {}
+
+# ---------------------------------------------------------------------------
 # Dynamic-resource prefix detection
 # ---------------------------------------------------------------------------
 
@@ -299,6 +317,7 @@ def async_cleanup_stale_entities(
 
     server_uuid_prefix = f"{server_uuid}_"
     orphans: list[er.RegistryEntry] = []
+    present_uids: set[str] = set()
 
     for entity_entry in registered:
         uid = entity_entry.unique_id
@@ -312,8 +331,34 @@ def async_cleanup_stale_entities(
             # Static entity — never prune.
             continue
 
-        if uid not in expected:
-            orphans.append(entity_entry)
+        if uid in expected:
+            present_uids.add(uid)
+            continue
+
+        # Dynamic entity whose resource is absent from this refresh. Only
+        # remove it after it has been missing for several consecutive
+        # successful refreshes, so a transient API gap does not delete it.
+        streak = _missing_streaks.get(uid, 0) + 1
+        _missing_streaks[uid] = streak
+        if streak < _MISSING_STREAK_THRESHOLD:
+            _LOGGER.debug(
+                "Entity %s (unique_id=%s) missing for %d consecutive refresh(es) "
+                "for entry %s; deferring removal until %d",
+                entity_entry.entity_id,
+                uid,
+                streak,
+                entry_id,
+                _MISSING_STREAK_THRESHOLD,
+            )
+            continue
+        orphans.append(entity_entry)
+
+    # Reset streaks for resources that came back and drop counters for
+    # entities that are no longer registered (removed above or elsewhere).
+    registered_uids = {e.unique_id for e in registered}
+    for uid in list(_missing_streaks):
+        if uid in present_uids or uid not in registered_uids:
+            _missing_streaks.pop(uid, None)
 
     if not orphans:
         return
@@ -330,6 +375,7 @@ def async_cleanup_stale_entities(
             entity_entry.entity_id,
             entity_entry.unique_id,
         )
+        _missing_streaks.pop(entity_entry.unique_id, None)
         ent_reg.async_remove(entity_entry.entity_id)
 
     # Remove any devices that are now empty after entity removal.

--- a/tests/test_cleanup.py
+++ b/tests/test_cleanup.py
@@ -6,7 +6,9 @@ from unittest.mock import MagicMock, patch
 
 from homeassistant.core import HomeAssistant
 
+from custom_components.unraid import cleanup as cleanup_module
 from custom_components.unraid.cleanup import (
+    _MISSING_STREAK_THRESHOLD,
     _is_dynamic_resource_id,
     async_cleanup_stale_entities,
     build_expected_dynamic_unique_ids,
@@ -330,6 +332,10 @@ _SENTINEL = object()
 class TestAsyncCleanupStaleEntities:
     """Integration-level tests for the full cleanup function."""
 
+    def setup_method(self) -> None:
+        """Isolate the module-level streak counters between tests."""
+        cleanup_module._missing_streaks.clear()
+
     def _make_system_coordinator(
         self,
         *,
@@ -368,7 +374,10 @@ class TestAsyncCleanupStaleEntities:
         stor_coord = self._make_storage_coordinator()
 
         with patch("custom_components.unraid.cleanup.er.async_get") as mock_reg:
-            async_cleanup_stale_entities(hass, "entry1", _UUID, sys_coord, stor_coord)
+            for _ in range(_MISSING_STREAK_THRESHOLD):
+                async_cleanup_stale_entities(
+                    hass, "entry1", _UUID, sys_coord, stor_coord
+                )
             # The entity registry should never be queried
             mock_reg.assert_not_called()
 
@@ -380,7 +389,10 @@ class TestAsyncCleanupStaleEntities:
         stor_coord = self._make_storage_coordinator(last_update_success=False)
 
         with patch("custom_components.unraid.cleanup.er.async_get") as mock_reg:
-            async_cleanup_stale_entities(hass, "entry1", _UUID, sys_coord, stor_coord)
+            for _ in range(_MISSING_STREAK_THRESHOLD):
+                async_cleanup_stale_entities(
+                    hass, "entry1", _UUID, sys_coord, stor_coord
+                )
             mock_reg.assert_not_called()
 
     async def test_skips_cleanup_when_coordinator_data_none(
@@ -391,7 +403,10 @@ class TestAsyncCleanupStaleEntities:
         stor_coord = self._make_storage_coordinator()
 
         with patch("custom_components.unraid.cleanup.er.async_get") as mock_reg:
-            async_cleanup_stale_entities(hass, "entry1", _UUID, sys_coord, stor_coord)
+            for _ in range(_MISSING_STREAK_THRESHOLD):
+                async_cleanup_stale_entities(
+                    hass, "entry1", _UUID, sys_coord, stor_coord
+                )
             mock_reg.assert_not_called()
 
     async def test_skips_cleanup_when_coordinator_data_wrong_type(
@@ -402,7 +417,10 @@ class TestAsyncCleanupStaleEntities:
         stor_coord = self._make_storage_coordinator()
 
         with patch("custom_components.unraid.cleanup.er.async_get") as mock_reg:
-            async_cleanup_stale_entities(hass, "entry1", _UUID, sys_coord, stor_coord)
+            for _ in range(_MISSING_STREAK_THRESHOLD):
+                async_cleanup_stale_entities(
+                    hass, "entry1", _UUID, sys_coord, stor_coord
+                )
             mock_reg.assert_not_called()
 
     async def test_removes_orphaned_container_entity(self, hass: HomeAssistant) -> None:
@@ -450,7 +468,10 @@ class TestAsyncCleanupStaleEntities:
                 return_value=[],
             ),
         ):
-            async_cleanup_stale_entities(hass, "entry1", _UUID, sys_coord, stor_coord)
+            for _ in range(_MISSING_STREAK_THRESHOLD):
+                async_cleanup_stale_entities(
+                    hass, "entry1", _UUID, sys_coord, stor_coord
+                )
 
         # Orphaned container entities removed; static entity untouched
         removed_ids = {call[0][0] for call in mock_reg.async_remove.call_args_list}
@@ -499,7 +520,10 @@ class TestAsyncCleanupStaleEntities:
                 return_value=[],
             ),
         ):
-            async_cleanup_stale_entities(hass, "entry1", _UUID, sys_coord, stor_coord)
+            for _ in range(_MISSING_STREAK_THRESHOLD):
+                async_cleanup_stale_entities(
+                    hass, "entry1", _UUID, sys_coord, stor_coord
+                )
 
         mock_reg.async_remove.assert_not_called()
 
@@ -541,7 +565,10 @@ class TestAsyncCleanupStaleEntities:
                 return_value=[],
             ),
         ):
-            async_cleanup_stale_entities(hass, "entry1", _UUID, sys_coord, stor_coord)
+            for _ in range(_MISSING_STREAK_THRESHOLD):
+                async_cleanup_stale_entities(
+                    hass, "entry1", _UUID, sys_coord, stor_coord
+                )
 
         removed_ids = {call[0][0] for call in mock_reg.async_remove.call_args_list}
         assert "sensor.server_disk_sdb_temp" in removed_ids
@@ -580,7 +607,10 @@ class TestAsyncCleanupStaleEntities:
                 return_value=[],
             ),
         ):
-            async_cleanup_stale_entities(hass, "entry1", _UUID, sys_coord, stor_coord)
+            for _ in range(_MISSING_STREAK_THRESHOLD):
+                async_cleanup_stale_entities(
+                    hass, "entry1", _UUID, sys_coord, stor_coord
+                )
 
         mock_reg.async_remove.assert_called_once_with(
             "sensor.server_share_movies_usage"
@@ -629,7 +659,10 @@ class TestAsyncCleanupStaleEntities:
                 return_value=[],
             ),
         ):
-            async_cleanup_stale_entities(hass, "entry1", _UUID, sys_coord, stor_coord)
+            for _ in range(_MISSING_STREAK_THRESHOLD):
+                async_cleanup_stale_entities(
+                    hass, "entry1", _UUID, sys_coord, stor_coord
+                )
 
         mock_reg.async_remove.assert_not_called()
 
@@ -666,7 +699,10 @@ class TestAsyncCleanupStaleEntities:
                 return_value=[],
             ),
         ):
-            async_cleanup_stale_entities(hass, "entry1", _UUID, sys_coord, stor_coord)
+            for _ in range(_MISSING_STREAK_THRESHOLD):
+                async_cleanup_stale_entities(
+                    hass, "entry1", _UUID, sys_coord, stor_coord
+                )
 
         mock_reg.async_remove.assert_not_called()
 
@@ -706,3 +742,99 @@ class TestAsyncRemoveConfigEntryDevice:
 
         result = await async_remove_config_entry_device(hass, entry, device)
         assert result is True
+
+    async def test_first_missing_refresh_keeps_entity(
+        self, hass: HomeAssistant
+    ) -> None:
+        """A single refresh without the resource must NOT remove its entities."""
+        sys_coord = self._make_system_coordinator(data_override=make_system_data())
+        stor_coord = self._make_storage_coordinator()
+
+        orphan = self._make_entity_entry(
+            f"{_UUID}_container_switch_oldapp", "switch.server_oldapp"
+        )
+
+        mock_reg = MagicMock()
+        mock_reg.async_entries_for_config_entry.return_value = [orphan]
+        mock_reg.async_remove = MagicMock()
+        mock_dev_reg = MagicMock()
+        mock_dev_reg.async_entries_for_config_entry.return_value = []
+
+        with (
+            patch(
+                "custom_components.unraid.cleanup.er.async_get", return_value=mock_reg
+            ),
+            patch(
+                "custom_components.unraid.cleanup.er.async_entries_for_config_entry",
+                return_value=[orphan],
+            ),
+            patch(
+                "custom_components.unraid.cleanup.dr.async_get",
+                return_value=mock_dev_reg,
+            ),
+            patch(
+                "custom_components.unraid.cleanup.dr.async_entries_for_config_entry",
+                return_value=[],
+            ),
+        ):
+            async_cleanup_stale_entities(hass, "entry1", _UUID, sys_coord, stor_coord)
+
+        mock_reg.async_remove.assert_not_called()
+        assert cleanup_module._missing_streaks[f"{_UUID}_container_switch_oldapp"] == 1
+
+    async def test_streak_resets_when_resource_returns(
+        self, hass: HomeAssistant
+    ) -> None:
+        """Alternating gaps must never reach the removal threshold."""
+        from unraid_api.models import DockerContainer
+
+        sys_coord_missing = self._make_system_coordinator(
+            data_override=make_system_data()
+        )
+        container = MagicMock(spec=DockerContainer)
+        container.name = "oldapp"
+        sys_data_present = make_system_data()
+        sys_data_present.containers = [container]
+        sys_coord_present = self._make_system_coordinator(
+            data_override=sys_data_present
+        )
+        stor_coord = self._make_storage_coordinator()
+
+        orphan = self._make_entity_entry(
+            f"{_UUID}_container_switch_oldapp", "switch.server_oldapp"
+        )
+        mock_reg = MagicMock()
+        mock_reg.async_entries_for_config_entry.return_value = [orphan]
+        mock_reg.async_remove = MagicMock()
+        mock_dev_reg = MagicMock()
+        mock_dev_reg.async_entries_for_config_entry.return_value = []
+
+        with (
+            patch(
+                "custom_components.unraid.cleanup.er.async_get", return_value=mock_reg
+            ),
+            patch(
+                "custom_components.unraid.cleanup.er.async_entries_for_config_entry",
+                return_value=[orphan],
+            ),
+            patch(
+                "custom_components.unraid.cleanup.dr.async_get",
+                return_value=mock_dev_reg,
+            ),
+            patch(
+                "custom_components.unraid.cleanup.dr.async_entries_for_config_entry",
+                return_value=[],
+            ),
+        ):
+            # missing, present, missing, missing — never 3 consecutive
+            for coord in (
+                sys_coord_missing,
+                sys_coord_present,
+                sys_coord_missing,
+                sys_coord_missing,
+            ):
+                async_cleanup_stale_entities(
+                    hass, "entry1", _UUID, coord, stor_coord
+                )
+
+        mock_reg.async_remove.assert_not_called()


### PR DESCRIPTION
Fixes #293.

## Summary

Since the stale-entity cleanup added in v2026.6.2, any dynamic entity whose resource was absent from **a single successful coordinator refresh** was removed immediately. The transient-failure guard only skips cleanup when the refresh itself fails — but the Unraid API can return a successful response that transiently omits resources (UPS data in particular, per the report), so one gap deleted healthy entities and broke dashboards and automations until the integration was reconfigured.

The cleanup now tracks a **consecutive-missing streak per unique_id** and only removes an entity after it has been missing for `3` consecutive successful refreshes (`_MISSING_STREAK_THRESHOLD`). A resource that comes back resets its streak; counters are dropped when the entity is finally removed or is no longer registered, keeping the dict bounded by the live dynamic-entity count.

Static entities remain untouched, coordinator-failure guards are unchanged, and device cleanup still only runs after actual entity removal.

## Testing

- Existing removal tests (`test_removes_orphaned_container_entity`, `test_removes_orphaned_disk_entities`, `test_removes_orphaned_share_entity`, `test_other_device_can_be_removed`) now drive the cleanup through the threshold instead of a single call.
- Added `test_first_missing_refresh_keeps_entity` — a single refresh without the resource keeps the entity and records streak=1.
- Added `test_streak_resets_when_resource_returns` — missing/present/missing/missing never reaches the threshold and nothing is removed.
- `setup_method` clears the module-level streak counters so tests are isolated.

Note: I could not execute the suite locally — `pytest-homeassistant-custom-component` requires a newer Python than this machine's 3.10 (the project targets 3.13). Both touched files byte-compile, and the streak algorithm was verified against a standalone simulation (missing→missing→missing removes; present resets; removed counters are dropped). CI runs the full suite.
