### PR TITLE
fix: validate server configuration URL

### DIFF
--- a/custom_components/unraid/__init__.py
+++ b/custom_components/unraid/__init__.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
-from urllib.parse import urlparse
 
 from homeassistant.const import (
     CONF_API_KEY,
@@ -32,6 +31,7 @@ from unraid_api.exceptions import (
     UnraidSSLError,
     UnraidTimeoutError,
 )
+from yarl import URL
 
 from .cleanup import async_cleanup_stale_entities
 from .const import (
@@ -91,9 +91,9 @@ def _build_server_info(server_info: ServerInfo, host: str, use_ssl: bool) -> dic
     # Determine configuration URL for device info
     configuration_url = server_info.local_url
     try:
-        parsed_url = urlparse(configuration_url or "")
-        valid_configuration_url = (
-            parsed_url.scheme in {"http", "https"} and parsed_url.hostname is not None
+        parsed_url = URL(configuration_url or "")
+        valid_configuration_url = parsed_url.scheme in {"http", "https"} and bool(
+            parsed_url.host
         )
     except ValueError:
         valid_configuration_url = False

--- a/custom_components/unraid/__init__.py
+++ b/custom_components/unraid/__init__.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
+from urllib.parse import urlparse
 
 from homeassistant.const import (
     CONF_API_KEY,
@@ -89,9 +90,17 @@ def _build_server_info(server_info: ServerInfo, host: str, use_ssl: bool) -> dic
 
     # Determine configuration URL for device info
     configuration_url = server_info.local_url
-    if not configuration_url and server_info.lan_ip:
+    try:
+        parsed_url = urlparse(configuration_url or "")
+        valid_configuration_url = (
+            parsed_url.scheme in {"http", "https"} and parsed_url.hostname is not None
+        )
+    except ValueError:
+        valid_configuration_url = False
+
+    if not valid_configuration_url:
         protocol = "https" if use_ssl else "http"
-        configuration_url = f"{protocol}://{server_info.lan_ip}"
+        configuration_url = f"{protocol}://{server_info.lan_ip or host}"
 
     return {
         "uuid": server_info.uuid,

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -603,10 +603,12 @@ async def test_setup_entry_uses_local_url_when_available(
     )
 
 
-async def test_setup_entry_falls_back_from_local_url_without_host(
+@pytest.mark.parametrize("local_url", ["http://:80", "http://tower.local:invalid"])
+async def test_setup_entry_falls_back_from_invalid_local_url(
     hass: HomeAssistant,
     mock_unraid_client_factory: type,
     mock_coordinator: MagicMock,
+    local_url: str,
 ) -> None:
     """Test setup falls back to the configured host for an invalid local URL."""
     entry = MockConfigEntry(
@@ -626,7 +628,7 @@ async def test_setup_entry_falls_back_from_local_url_without_host(
     client = create_mock_unraid_client(
         server_info=make_server_info(
             uuid="test-uuid",
-            local_url="http://:80",
+            local_url=local_url,
             lan_ip="",
         )
     )

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -603,6 +603,61 @@ async def test_setup_entry_uses_local_url_when_available(
     )
 
 
+async def test_setup_entry_falls_back_from_local_url_without_host(
+    hass: HomeAssistant,
+    mock_unraid_client_factory: type,
+    mock_coordinator: MagicMock,
+) -> None:
+    """Test setup falls back to the configured host for an invalid local URL."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="tower",
+        data={
+            CONF_HOST: "192.168.1.100",
+            CONF_API_KEY: "test-api-key",
+            CONF_SSL: True,
+        },
+        unique_id="test-uuid",
+    )
+    entry.add_to_hass(hass)
+
+    from tests.conftest import create_mock_unraid_client, make_server_info
+
+    client = create_mock_unraid_client(
+        server_info=make_server_info(
+            uuid="test-uuid",
+            local_url="http://:80",
+            lan_ip="",
+        )
+    )
+    mock_unraid_client_factory.return_value = client
+
+    with (
+        patch(
+            "custom_components.unraid.UnraidSystemCoordinator",
+            return_value=mock_coordinator,
+        ),
+        patch(
+            "custom_components.unraid.UnraidStorageCoordinator",
+            return_value=mock_coordinator,
+        ),
+        patch(
+            "custom_components.unraid.UnraidInfraCoordinator",
+            return_value=mock_coordinator,
+        ),
+        patch("custom_components.unraid.async_get_clientsession") as mock_session,
+        patch.object(
+            hass.config_entries, "async_forward_entry_setups", return_value=None
+        ),
+    ):
+        mock_session.return_value = MagicMock()
+        await async_setup_entry(hass, entry)
+
+    assert (
+        entry.runtime_data.server_info["configuration_url"] == "https://192.168.1.100"
+    )
+
+
 async def test_setup_entry_uses_host_when_hostname_missing(
     hass: HomeAssistant,
     mock_unraid_client_factory: type,


### PR DESCRIPTION
Fixes #299 

## Changes Made

<!-- List the specific changes made in this PR -->

- validate the server's local URL before using it for Home Assistant device info
- fall back to the LAN IP, then the configured host, when the URL is invalid
- add a regression test for a hostless local URL

## Testing

<!-- Describe the testing you've done -->

- `pytest tests/test_init.py -o addopts='' -q` — 20 passed
- full suite — 1,059 passed; 2 unrelated failures also reproduce on `main`
- Manual testing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of server configuration URLs.
  * Invalid or incomplete URLs now fall back to a valid address using the configured protocol and server host.
  * Setup now correctly handles invalid local URLs when no usable LAN IP is available.

* **Tests**
  * Added coverage for configuration fallback behaviour with invalid local URLs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->