### PR TITLE
feat: bump unraid-api to 1.13.1 and add new entities

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -23,7 +23,7 @@ Bypass `unraid-api`".
 - **Class prefix**: `Unraid`
 - **Code path**: `custom_components/unraid/`
 - **Test path**: `tests/`
-- **Python**: 3.13+ | **HA**: 2026.5.0+ | **Dep**: `unraid-api>=1.11.0`
+- **Python**: 3.13+ | **HA**: 2026.5.0+ | **Dep**: `unraid-api>=1.13.0`
 - **Platforms**: `sensor`, `binary_sensor`, `switch`, `button`
 - **iot_class**: `local_polling`
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -23,7 +23,7 @@ Bypass `unraid-api`".
 - **Class prefix**: `Unraid`
 - **Code path**: `custom_components/unraid/`
 - **Test path**: `tests/`
-- **Python**: 3.13+ | **HA**: 2026.5.0+ | **Dep**: `unraid-api>=1.13.0`
+- **Python**: 3.13+ | **HA**: 2026.5.0+ | **Dep**: `unraid-api>=1.13.1`
 - **Platforms**: `sensor`, `binary_sensor`, `switch`, `button`
 - **iot_class**: `local_polling`
 

--- a/.github/instructions/api.instructions.md
+++ b/.github/instructions/api.instructions.md
@@ -89,6 +89,6 @@ data = await client.get_system_info()
 
 ## Dependency Management
 
-- Current runtime dependency: `unraid-api>=1.13.0`.
+- Current runtime dependency: `unraid-api>=1.13.1`.
 - Dependency upgrades require review first.
 - If upgraded, sync `manifest.json`, docs, and agent instructions in the same PR.

--- a/.github/instructions/api.instructions.md
+++ b/.github/instructions/api.instructions.md
@@ -89,6 +89,6 @@ data = await client.get_system_info()
 
 ## Dependency Management
 
-- Current runtime dependency: `unraid-api>=1.11.0`.
+- Current runtime dependency: `unraid-api>=1.13.0`.
 - Dependency upgrades require review first.
 - If upgraded, sync `manifest.json`, docs, and agent instructions in the same PR.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,7 +44,7 @@ The only sanctioned data flow is:
 | **Test path**        | `tests/`                                      |
 | **Python**           | 3.13+                                         |
 | **HA minimum**       | 2026.5.0                                      |
-| **Key dependency**   | `unraid-api>=1.13.0`                          |
+| **Key dependency**   | `unraid-api>=1.13.1`                          |
 | **iot_class**        | `local_polling`                               |
 | **Config flow**      | Yes (UI only, no YAML)                        |
 | **Platforms**        | `sensor`, `binary_sensor`, `switch`, `button` |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,7 +44,7 @@ The only sanctioned data flow is:
 | **Test path**        | `tests/`                                      |
 | **Python**           | 3.13+                                         |
 | **HA minimum**       | 2026.5.0                                      |
-| **Key dependency**   | `unraid-api>=1.11.0`                          |
+| **Key dependency**   | `unraid-api>=1.13.0`                          |
 | **iot_class**        | `local_polling`                               |
 | **Config flow**      | Yes (UI only, no YAML)                        |
 | **Platforms**        | `sensor`, `binary_sensor`, `switch`, `button` |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Calendar Versioning](https://calver.org/) (YYYY.MM.
 
 ### Added
 
-- **Docker Container Autostart Switch**: Added a configuration switch (`switch.*_container_*_autostart`) for each Docker container allowing users to toggle whether a container starts automatically on Unraid array start, powered by `unraid-api` v1.13.0's `update_container_autostart` mutation.
+- **Docker Container Autostart Switch**: Added a configuration switch (`switch.*_container_*_autostart`) for each Docker container allowing users to toggle whether a container starts automatically on Unraid array start, powered by `unraid-api` v1.13.1's `update_container_autostart` mutation.
 - **Network Interface Link Binary Sensors**: Added connectivity diagnostic binary sensors (`binary_sensor.*_network_*_link`) for monitorable network interfaces (physical NICs, bonds, bridges, and VLANs) reporting operational link state (`up` / `down`) along with MAC address, IP address, duplex, MTU, speed, and interface type.
 - **Network Interface Speed & IP Sensors**: Added diagnostic sensors (`sensor.*_network_*_speed` in Mbit/s and `sensor.*_network_*_ip`) reporting negotiated link speeds and network IP addressing with IPv4/IPv6 details.
 - **Plugin Installation Status Binary Sensor**: Added diagnostic binary sensor (`binary_sensor.*_plugin_installation_in_progress`) reporting whether plugin installation or update operations are actively running on the Unraid server.
@@ -18,8 +18,8 @@ and this project adheres to [Calendar Versioning](https://calver.org/) (YYYY.MM.
 
 ### Changed
 
-- **Upgrade `unraid-api` to v1.13.0**: Upgraded dependency to `unraid-api>=1.13.0` which brings Unraid OS 7.3.x and GraphQL API 4.37.x schema compatibility, network interface queries, Docker organizer models, container autostart configuration mutations, individual array disk mount/unmount and statistics reset mutations, and server identity queries.
-- **Refactor Plugin Query to use Typed Client Method**: Replaced direct GraphQL query `query { installedUnraidPlugins }` in `UnraidInfraCoordinator` with the official typed `api_client.get_installed_unraid_plugins()` method provided in `unraid-api` v1.13.0, eliminating direct GraphQL usage and ensuring full adherence to the API boundary architecture.
+- **Upgrade `unraid-api` to v1.13.1**: Upgraded dependency to `unraid-api>=1.13.1` which brings Unraid OS 7.3.x and GraphQL API 4.37.x schema compatibility, network interface queries, Docker organizer models, container autostart configuration mutations (with GraphQL input type fix), individual array disk mount/unmount and statistics reset mutations, and server identity queries.
+- **Refactor Plugin Query to use Typed Client Method**: Replaced direct GraphQL query `query { installedUnraidPlugins }` in `UnraidInfraCoordinator` with the official typed `api_client.get_installed_unraid_plugins()` method provided in `unraid-api` v1.13.1, eliminating direct GraphQL usage and ensuring full adherence to the API boundary architecture.
 
 ## [2026.9.0] - 2026-09-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Calendar Versioning](https://calver.org/) (YYYY.MM.
 
 ## [Unreleased]
 
+## [2026.9.1] - 2026-09-04
+
 ### Added
 
 - **Docker Container Autostart Switch**: Added a configuration switch (`switch.*_container_*_autostart`, disabled by default) for each Docker container allowing users to toggle whether a container starts automatically on Unraid array start, powered by `unraid-api` v1.13.1's `update_container_autostart` mutation.
@@ -417,7 +419,11 @@ and this project adheres to [Calendar Versioning](https://calver.org/) (YYYY.MM.
 - HTTPS required for API communication
 - API key authentication via `x-api-key` header
 
-[Unreleased]: https://github.com/ruaan-deysel/ha-unraid/compare/v2026.6.3...HEAD
+[Unreleased]: https://github.com/ruaan-deysel/ha-unraid/compare/v2026.9.1...HEAD
+[2026.9.1]: https://github.com/ruaan-deysel/ha-unraid/compare/v2026.9.0...v2026.9.1
+[2026.9.0]: https://github.com/ruaan-deysel/ha-unraid/compare/v2026.8.1...v2026.9.0
+[2026.8.1]: https://github.com/ruaan-deysel/ha-unraid/compare/v2026.8.0...v2026.8.1
+[2026.8.0]: https://github.com/ruaan-deysel/ha-unraid/compare/v2026.6.3...v2026.8.0
 [2026.6.3]: https://github.com/ruaan-deysel/ha-unraid/compare/v2026.6.2...v2026.6.3
 [2026.6.2]: https://github.com/ruaan-deysel/ha-unraid/compare/v2026.6.1...v2026.6.2
 [2026.6.1]: https://github.com/ruaan-deysel/ha-unraid/compare/v2026.6.0...v2026.6.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Calendar Versioning](https://calver.org/) (YYYY.MM.
 
 ## [Unreleased]
 
+### Added
+
+- **Docker Container Autostart Switch**: Added a configuration switch (`switch.*_container_*_autostart`) for each Docker container allowing users to toggle whether a container starts automatically on Unraid array start, powered by `unraid-api` v1.13.0's `update_container_autostart` mutation.
+- **Network Interface Link Binary Sensors**: Added connectivity diagnostic binary sensors (`binary_sensor.*_network_*_link`) for monitorable network interfaces (physical NICs, bonds, bridges, and VLANs) reporting operational link state (`up` / `down`) along with MAC address, IP address, duplex, MTU, speed, and interface type.
+- **Network Interface Speed & IP Sensors**: Added diagnostic sensors (`sensor.*_network_*_speed` in Mbit/s and `sensor.*_network_*_ip`) reporting negotiated link speeds and network IP addressing with IPv4/IPv6 details.
+- **Plugin Installation Status Binary Sensor**: Added diagnostic binary sensor (`binary_sensor.*_plugin_installation_in_progress`) reporting whether plugin installation or update operations are actively running on the Unraid server.
+- **Recalculate Notifications Button**: Added diagnostic button (`button.*_recalculate_notifications`) to trigger immediate recalculation of the notification overview counts on the Unraid server.
+- **Clear Disk Statistics Button**: Added per-disk button (`button.*_disk_*_clear_statistics`, disabled by default) allowing users to clear read, write, and error statistics on individual array disks directly from Home Assistant.
+
 ### Changed
 
 - **Upgrade `unraid-api` to v1.13.0**: Upgraded dependency to `unraid-api>=1.13.0` which brings Unraid OS 7.3.x and GraphQL API 4.37.x schema compatibility, network interface queries, Docker organizer models, container autostart configuration mutations, individual array disk mount/unmount and statistics reset mutations, and server identity queries.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Calendar Versioning](https://calver.org/) (YYYY.MM.
 
 ## [Unreleased]
 
+### Changed
+
+- **Upgrade `unraid-api` to v1.13.0**: Upgraded dependency to `unraid-api>=1.13.0` which brings Unraid OS 7.3.x and GraphQL API 4.37.x schema compatibility, network interface queries, Docker organizer models, container autostart configuration mutations, individual array disk mount/unmount and statistics reset mutations, and server identity queries.
+- **Refactor Plugin Query to use Typed Client Method**: Replaced direct GraphQL query `query { installedUnraidPlugins }` in `UnraidInfraCoordinator` with the official typed `api_client.get_installed_unraid_plugins()` method provided in `unraid-api` v1.13.0, eliminating direct GraphQL usage and ensuring full adherence to the API boundary architecture.
+
 ## [2026.9.0] - 2026-09-02
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Calendar Versioning](https://calver.org/) (YYYY.MM.
 
 ### Added
 
-- **Docker Container Autostart Switch**: Added a configuration switch (`switch.*_container_*_autostart`) for each Docker container allowing users to toggle whether a container starts automatically on Unraid array start, powered by `unraid-api` v1.13.1's `update_container_autostart` mutation.
+- **Docker Container Autostart Switch**: Added a configuration switch (`switch.*_container_*_autostart`, disabled by default) for each Docker container allowing users to toggle whether a container starts automatically on Unraid array start, powered by `unraid-api` v1.13.1's `update_container_autostart` mutation.
 - **Network Interface Link Binary Sensors**: Added connectivity diagnostic binary sensors (`binary_sensor.*_network_*_link`) for monitorable network interfaces (physical NICs, bonds, bridges, and VLANs) reporting operational link state (`up` / `down`) along with MAC address, IP address, duplex, MTU, speed, and interface type.
 - **Network Interface Speed & IP Sensors**: Added diagnostic sensors (`sensor.*_network_*_speed` in Mbit/s and `sensor.*_network_*_ip`) reporting negotiated link speeds and network IP addressing with IPv4/IPv6 details.
 - **Plugin Installation Status Binary Sensor**: Added diagnostic binary sensor (`binary_sensor.*_plugin_installation_in_progress`) reporting whether plugin installation or update operations are actively running on the Unraid server.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@ Rule: Never Bypass `unraid-api`".
 
 ## Quick Reference
 
-- **Domain**: `unraid` | **Prefix**: `Unraid` | **Python**: 3.13+ | **HA**: 2026.5.0+ | **Dep**: `unraid-api>=1.11.0`
+- **Domain**: `unraid` | **Prefix**: `Unraid` | **Python**: 3.13+ | **HA**: 2026.5.0+ | **Dep**: `unraid-api>=1.13.0`
 - **Code**: `custom_components/unraid/` | **Tests**: `tests/`
 - **Lint**: `./script/lint` | **Test**: `./script/test` | **Check**: `./script/check`
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@ Rule: Never Bypass `unraid-api`".
 
 ## Quick Reference
 
-- **Domain**: `unraid` | **Prefix**: `Unraid` | **Python**: 3.13+ | **HA**: 2026.5.0+ | **Dep**: `unraid-api>=1.13.0`
+- **Domain**: `unraid` | **Prefix**: `Unraid` | **Python**: 3.13+ | **HA**: 2026.5.0+ | **Dep**: `unraid-api>=1.13.1`
 - **Code**: `custom_components/unraid/` | **Tests**: `tests/`
 - **Lint**: `./script/lint` | **Test**: `./script/test` | **Check**: `./script/check`
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -18,7 +18,7 @@ Rule: Never Bypass `unraid-api`".
 
 ## Quick Reference
 
-- **Domain**: `unraid` | **Prefix**: `Unraid` | **Python**: 3.13+ | **HA**: 2026.5.0+ | **Dep**: `unraid-api>=1.11.0`
+- **Domain**: `unraid` | **Prefix**: `Unraid` | **Python**: 3.13+ | **HA**: 2026.5.0+ | **Dep**: `unraid-api>=1.13.0`
 - **Code**: `custom_components/unraid/` | **Tests**: `tests/`
 - **Lint**: `./script/lint` | **Test**: `./script/test` | **Check**: `./script/check`
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -18,7 +18,7 @@ Rule: Never Bypass `unraid-api`".
 
 ## Quick Reference
 
-- **Domain**: `unraid` | **Prefix**: `Unraid` | **Python**: 3.13+ | **HA**: 2026.5.0+ | **Dep**: `unraid-api>=1.13.0`
+- **Domain**: `unraid` | **Prefix**: `Unraid` | **Python**: 3.13+ | **HA**: 2026.5.0+ | **Dep**: `unraid-api>=1.13.1`
 - **Code**: `custom_components/unraid/` | **Tests**: `tests/`
 - **Lint**: `./script/lint` | **Test**: `./script/test` | **Check**: `./script/check`
 

--- a/custom_components/unraid/binary_sensor.py
+++ b/custom_components/unraid/binary_sensor.py
@@ -1080,10 +1080,12 @@ class NetworkInterfaceLinkBinarySensor(
         return None
 
     @property
-    def is_on(self) -> bool:
+    def is_on(self) -> bool | None:
         """Return True if the interface operational state is up."""
         iface = self._get_interface()
-        if iface is None or not iface.operstate:
+        if iface is None:
+            return None
+        if not iface.operstate:
             return False
         return iface.operstate.lower() == "up"
 
@@ -1147,10 +1149,12 @@ class PluginInstallingBinarySensor(UnraidBinarySensorEntity[UnraidSystemCoordina
         )
 
     @property
-    def is_on(self) -> bool:
+    def is_on(self) -> bool | None:
         """Return True if any plugin installation operation is active."""
         data: UnraidSystemData | None = self.coordinator.data
-        if data is None or not data.plugin_operations:
+        if data is None:
+            return None
+        if not data.plugin_operations:
             return False
         return any(
             op.status is not None

--- a/custom_components/unraid/binary_sensor.py
+++ b/custom_components/unraid/binary_sensor.py
@@ -22,7 +22,7 @@ from unraid_api.const import (
     DISK_STATUS_WRONG,
 )
 
-from .const import ARRAY_STATE_STARTED
+from .const import ARRAY_STATE_STARTED, is_monitorable_interface
 from .coordinator import (
     UnraidInfraCoordinator,
     UnraidStorageCoordinator,
@@ -36,7 +36,13 @@ from .entity import (
 
 if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant
-    from unraid_api.models import ArrayDisk, DockerContainer, Service, UPSDevice
+    from unraid_api.models import (
+        ArrayDisk,
+        DockerContainer,
+        InfoNetworkInterface,
+        Service,
+        UPSDevice,
+    )
 
     from . import UnraidConfigEntry
     from .coordinator import (
@@ -1029,6 +1035,148 @@ class FilesystemsUnmountableBinarySensor(
         return {"count": data.vars.fs_num_unmountable}
 
 
+class NetworkInterfaceLinkBinarySensor(
+    UnraidBinarySensorEntity[UnraidSystemCoordinator]
+):
+    """
+    Binary sensor representing network interface operational link status.
+
+    ON = Interface link is UP
+    OFF = Interface link is DOWN or other state
+    """
+
+    _attr_device_class = BinarySensorDeviceClass.CONNECTIVITY
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_translation_key = "network_interface_link"
+
+    def __init__(
+        self,
+        coordinator: UnraidSystemCoordinator,
+        server_uuid: str,
+        server_name: str,
+        interface_name: str,
+        server_info: dict | None = None,
+    ) -> None:
+        """Initialize network interface link binary sensor."""
+        self._interface_name = interface_name
+        super().__init__(
+            coordinator=coordinator,
+            server_uuid=server_uuid,
+            server_name=server_name,
+            resource_id=f"network_{interface_name}_link",
+            name=f"Network {interface_name} Link",
+            server_info=server_info,
+        )
+        self._attr_translation_placeholders = {"name": interface_name}
+
+    def _get_interface(self) -> InfoNetworkInterface | None:
+        """Get current network interface from coordinator data."""
+        data: UnraidSystemData | None = self.coordinator.data
+        if data is None:
+            return None
+        for iface in data.network_interfaces:
+            if iface.name == self._interface_name:
+                return iface
+        return None
+
+    @property
+    def is_on(self) -> bool:
+        """Return True if the interface operational state is up."""
+        iface = self._get_interface()
+        if iface is None or not iface.operstate:
+            return False
+        return iface.operstate.lower() == "up"
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return interface attributes."""
+        iface = self._get_interface()
+        if iface is None:
+            return {}
+        attrs: dict[str, Any] = {}
+        if iface.macAddress:
+            attrs["mac_address"] = iface.macAddress
+        if iface.ipAddress:
+            attrs["ip_address"] = iface.ipAddress
+        if iface.duplex:
+            attrs["duplex"] = iface.duplex
+        if iface.mtu is not None:
+            attrs["mtu"] = iface.mtu
+        if iface.speed is not None:
+            attrs["speed_mbps"] = iface.speed
+        if iface.vlanId is not None:
+            attrs["vlan_id"] = iface.vlanId
+        if iface.virtual is not None:
+            attrs["virtual"] = iface.virtual
+        if iface.internal is not None:
+            attrs["internal"] = iface.internal
+        if iface.protocol:
+            attrs["protocol"] = iface.protocol
+        if iface.type:
+            attrs["interface_type"] = iface.type
+        return attrs
+
+
+class PluginInstallingBinarySensor(UnraidBinarySensorEntity[UnraidSystemCoordinator]):
+    """
+    Binary sensor indicating whether an Unraid plugin installation/update is active.
+
+    ON = Plugin installation is in progress
+    OFF = Idle (no operations in progress)
+    """
+
+    _attr_device_class = BinarySensorDeviceClass.RUNNING
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_translation_key = "plugin_installing"
+
+    def __init__(
+        self,
+        coordinator: UnraidSystemCoordinator,
+        server_uuid: str,
+        server_name: str,
+        server_info: dict | None = None,
+    ) -> None:
+        """Initialize plugin installing binary sensor."""
+        super().__init__(
+            coordinator=coordinator,
+            server_uuid=server_uuid,
+            server_name=server_name,
+            resource_id="plugin_installing",
+            name="Plugin Installation in Progress",
+            server_info=server_info,
+        )
+
+    @property
+    def is_on(self) -> bool:
+        """Return True if any plugin installation operation is active."""
+        data: UnraidSystemData | None = self.coordinator.data
+        if data is None or not data.plugin_operations:
+            return False
+        return any(
+            op.status is not None
+            and op.status.upper() in ("RUNNING", "PENDING", "IN_PROGRESS")
+            for op in data.plugin_operations
+        )
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return active plugin operations metadata."""
+        data: UnraidSystemData | None = self.coordinator.data
+        if data is None:
+            return {}
+        active = [
+            {"id": op.id, "name": op.name, "status": op.status, "url": op.url}
+            for op in data.plugin_operations
+            if op.status is not None
+            and op.status.upper() in ("RUNNING", "PENDING", "IN_PROGRESS")
+        ]
+        return {
+            "active_operations": active,
+            "active_count": len(active),
+            "total_operations": len(data.plugin_operations),
+        }
+
+
 async def async_setup_entry(
     hass: HomeAssistant,  # noqa: ARG001
     entry: UnraidConfigEntry,
@@ -1150,6 +1298,13 @@ async def async_setup_entry(
         ]
     )
 
+    # Plugin installation in progress binary sensor
+    entities.append(
+        PluginInstallingBinarySensor(
+            system_coordinator, server_uuid, server_name, server_info
+        )
+    )
+
     _LOGGER.debug("Adding %d binary_sensor entities", len(entities))
     async_add_entities(entities)
 
@@ -1167,6 +1322,33 @@ async def async_setup_entry(
             create_entities=lambda container: [
                 ContainerUpdateAvailableBinarySensor(
                     system_coordinator, server_uuid, server_name, container
+                )
+            ],
+        )
+    )
+
+    # Network interface link status binary sensors (Unraid API 4.35+ / unraid-api 1.13+)
+    entry.async_on_unload(
+        async_add_dynamic_resource_entities(
+            coordinator=system_coordinator,
+            async_add_entities=async_add_entities,
+            get_resources=lambda: [
+                iface
+                for iface in (
+                    system_coordinator.data.network_interfaces
+                    if system_coordinator.data
+                    else []
+                )
+                if iface.name and is_monitorable_interface(iface.name)
+            ],
+            get_key=lambda iface: iface.name or "",
+            create_entities=lambda iface: [
+                NetworkInterfaceLinkBinarySensor(
+                    system_coordinator,
+                    server_uuid,
+                    server_name,
+                    iface.name or "",
+                    server_info,
                 )
             ],
         )

--- a/custom_components/unraid/button.py
+++ b/custom_components/unraid/button.py
@@ -710,6 +710,112 @@ class DeleteAllArchivedNotificationsButton(UnraidButtonEntity[UnraidSystemCoordi
             ) from err
 
 
+class RecalculateNotificationsButton(UnraidButtonEntity[UnraidSystemCoordinator]):
+    """
+    Button to recalculate notification overview counts.
+
+    Forces the Unraid backend to recalculate notification overview counts.
+    Disabled by default - users enable when needed.
+    """
+
+    _attr_translation_key = "recalculate_notifications"
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_entity_registry_enabled_default = False
+
+    def __init__(
+        self,
+        coordinator: UnraidSystemCoordinator,
+        server_uuid: str,
+        server_name: str,
+        server_info: dict | None = None,
+    ) -> None:
+        """Initialize recalculate notifications button."""
+        super().__init__(
+            coordinator=coordinator,
+            server_uuid=server_uuid,
+            server_name=server_name,
+            resource_id="recalculate_notifications",
+            name="Recalculate Notifications",
+            server_info=server_info,
+        )
+
+    async def async_press(self) -> None:
+        """Handle button press to recalculate notification counts."""
+        _LOGGER.info("Recalculating notifications on %s", self._server_name)
+        try:
+            await self.coordinator.async_recalculate_notifications()
+            _LOGGER.debug("Recalculate notifications command sent successfully")
+        except UnraidAPIError as err:
+            _LOGGER.error("Failed to recalculate notifications: %s", err)
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="recalculate_notifications_failed",
+                translation_placeholders={"error": str(err)},
+            ) from err
+
+
+class ClearDiskStatisticsButton(UnraidButtonEntity[UnraidStorageCoordinator]):
+    """
+    Button to clear read, write, and error statistics for an individual disk.
+
+    Resets the statistics counters on an individual array or pool disk.
+    Disabled by default - users enable per disk when needed.
+    """
+
+    _attr_translation_key = "disk_clear_statistics"
+    _attr_entity_category = EntityCategory.CONFIG
+    _attr_entity_registry_enabled_default = False
+
+    def __init__(
+        self,
+        coordinator: UnraidStorageCoordinator,
+        server_uuid: str,
+        server_name: str,
+        disk_id: str,
+        disk_name: str,
+        server_info: dict | None = None,
+    ) -> None:
+        """Initialize clear disk statistics button."""
+        self._disk_id = disk_id
+        self._disk_name = disk_name
+        super().__init__(
+            coordinator=coordinator,
+            server_uuid=server_uuid,
+            server_name=server_name,
+            resource_id=f"disk_{disk_id}_clear_statistics",
+            name=f"Disk {self._disk_name} Clear Statistics",
+            server_info=server_info,
+        )
+        self._attr_translation_placeholders = {"name": self._disk_name}
+
+    async def async_press(self) -> None:
+        """Handle button press to clear disk statistics."""
+        _LOGGER.info(
+            "Clearing statistics for disk %s on %s",
+            self._disk_name,
+            self._server_name,
+        )
+        try:
+            await self.coordinator.async_clear_disk_statistics(self._disk_id)
+            _LOGGER.debug(
+                "Cleared statistics for disk %s successfully", self._disk_name
+            )
+        except UnraidAPIError as err:
+            _LOGGER.error(
+                "Failed to clear statistics for disk %s: %s",
+                self._disk_name,
+                err,
+            )
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="clear_disk_stats_failed",
+                translation_placeholders={
+                    "name": self._disk_name,
+                    "error": str(err),
+                },
+            ) from err
+
+
 # =============================================================================
 # Platform Setup
 # =============================================================================
@@ -764,6 +870,11 @@ async def async_setup_entry(
     )
     entities.append(
         DeleteAllArchivedNotificationsButton(
+            system_coordinator, server_uuid, server_name, server_info
+        )
+    )
+    entities.append(
+        RecalculateNotificationsButton(
             system_coordinator, server_uuid, server_name, server_info
         )
     )
@@ -838,6 +949,46 @@ async def async_setup_entry(
                 VMResetButton(
                     system_coordinator, server_uuid, server_name, vm, server_info
                 ),
+            ],
+        )
+    )
+
+    # Per-disk statistics clear buttons: added dynamically when disks appear
+    def _get_all_disks() -> list[Any]:
+        data = storage_coordinator.data
+        if not data:
+            return []
+        disks: list[Any] = []
+        for disk in [
+            *(data.disks or []),
+            *(data.parities or []),
+            *(data.caches or []),
+        ]:
+            if isinstance(getattr(disk, "id", None), str) and disk.id:
+                disks.append(disk)
+        if (
+            data.boot is not None
+            and isinstance(getattr(data.boot, "id", None), str)
+            and data.boot.id
+        ):
+            disks.append(data.boot)
+        return disks
+
+    entry.async_on_unload(
+        async_add_dynamic_resource_entities(
+            coordinator=storage_coordinator,
+            async_add_entities=async_add_entities,
+            get_resources=_get_all_disks,
+            get_key=lambda disk: disk.id,
+            create_entities=lambda disk: [
+                ClearDiskStatisticsButton(
+                    storage_coordinator,
+                    server_uuid,
+                    server_name,
+                    disk.id,
+                    disk.name or disk.id,
+                    server_info,
+                )
             ],
         )
     )

--- a/custom_components/unraid/button.py
+++ b/custom_components/unraid/button.py
@@ -953,7 +953,9 @@ async def async_setup_entry(
         )
     )
 
-    # Per-disk statistics clear buttons: added dynamically when disks appear
+    # Per-disk statistics clear buttons: added dynamically when array disks appear.
+    # Excludes data.boot (flash USB drive) as clear_array_disk_statistics only
+    # applies to array/pool storage devices.
     def _get_all_disks() -> list[Any]:
         data = storage_coordinator.data
         if not data:
@@ -966,12 +968,6 @@ async def async_setup_entry(
         ]:
             if isinstance(getattr(disk, "id", None), str) and disk.id:
                 disks.append(disk)
-        if (
-            data.boot is not None
-            and isinstance(getattr(data.boot, "id", None), str)
-            and data.boot.id
-        ):
-            disks.append(data.boot)
         return disks
 
     entry.async_on_unload(

--- a/custom_components/unraid/cleanup.py
+++ b/custom_components/unraid/cleanup.py
@@ -75,6 +75,7 @@ _missing_streaks: dict[str, int] = {}
 # "temp_" covers per-hardware-temperature-sensor entities (not "temperature_average").
 _DYNAMIC_RESOURCE_ID_PREFIXES: Final[tuple[str, ...]] = (
     "container_switch_",  # per-container switch
+    "container_autostart_",  # per-container autostart switch
     "container_restart_",  # per-container restart button
     "container_update_",  # per-container update entity (update platform)
     "vm_switch_",  # per-VM switch
@@ -97,10 +98,15 @@ _STATIC_CONTAINER_RESOURCE_IDS: Final[frozenset[str]] = frozenset(
 # Static resource ids that start with "network_" (and must not be cleaned up)
 _STATIC_NETWORK_RESOURCE_IDS: Final[frozenset[str]] = frozenset({"network_access"})
 
-# Network-interface sensors use resource_id = "network_{name}_{rx|tx}".
+# Network-metrics throughput sensors use resource_id = "network_{name}_{rx|tx}".
+_NETWORK_METRICS_RESOURCE_ID_RE: Final = re.compile(
+    r"^network_(?P<name>.+?)_(?:rx|tx)$"
+)
+
+# Network-interface state/speed/ip entities use "network_{name}_{link|speed|ip}".
 # This pattern distinguishes them from the static "network_access" sensor.
 _NETWORK_INTERFACE_RESOURCE_ID_RE: Final = re.compile(
-    r"^network_(?P<name>.+?)_(?:rx|tx)$"
+    r"^network_(?P<name>.+?)_(?:link|speed|ip)$"
 )
 
 
@@ -124,12 +130,15 @@ def _is_dynamic_resource_id(resource_id: str) -> bool:
     ):
         return True
 
-    # Network-interface throughput sensors: network_{interface}_{rx|tx}
+    # Network-interface throughput and state sensors
     # Only those NOT in the static allow-list count as dynamic.
     return (
         resource_id.startswith("network_")
         and resource_id not in _STATIC_NETWORK_RESOURCE_IDS
-        and bool(_NETWORK_INTERFACE_RESOURCE_ID_RE.match(resource_id))
+        and bool(
+            _NETWORK_METRICS_RESOURCE_ID_RE.match(resource_id)
+            or _NETWORK_INTERFACE_RESOURCE_ID_RE.match(resource_id)
+        )
     )
 
 
@@ -147,9 +156,11 @@ def _get_dynamic_resource_category(resource_id: str) -> str | None:
     if (
         resource_id.startswith("network_")
         and resource_id not in _STATIC_NETWORK_RESOURCE_IDS
-        and bool(_NETWORK_INTERFACE_RESOURCE_ID_RE.match(resource_id))
     ):
-        return "network_metrics"
+        if bool(_NETWORK_METRICS_RESOURCE_ID_RE.match(resource_id)):
+            return "network_metrics"
+        if bool(_NETWORK_INTERFACE_RESOURCE_ID_RE.match(resource_id)):
+            return "network_interfaces"
     return None
 
 
@@ -165,6 +176,7 @@ def _build_system_dynamic_unique_ids(
         expected.update(
             {
                 f"{pfx}container_switch_{name}",
+                f"{pfx}container_autostart_{name}",
                 f"{pfx}container_restart_{name}",
                 f"{pfx}container_{name}_cpu",
                 f"{pfx}container_{name}_memory",
@@ -217,6 +229,16 @@ def _build_system_dynamic_unique_ids(
                 }
             )
 
+    for iface in sys_data.network_interfaces or []:
+        if iface.name is not None:
+            expected.update(
+                {
+                    f"{pfx}network_{iface.name}_link",
+                    f"{pfx}network_{iface.name}_speed",
+                    f"{pfx}network_{iface.name}_ip",
+                }
+            )
+
     return expected
 
 
@@ -242,6 +264,7 @@ def _build_storage_dynamic_unique_ids(
                 f"{pfx}disk_{disk.id}_usage",
                 f"{pfx}disk_health_{disk.id}",
                 f"{pfx}disk_spin_{disk.id}",
+                f"{pfx}disk_{disk.id}_clear_statistics",
             }
         )
 

--- a/custom_components/unraid/const.py
+++ b/custom_components/unraid/const.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from typing import Final
 
 # =============================================================================
@@ -35,6 +36,7 @@ __all__ = [
     "CONTAINER_STATE_EXITED",
     "CONTAINER_STATE_PAUSED",
     "CONTAINER_STATE_RUNNING",
+    "MONITORABLE_INTERFACE_RE",
     "VM_STATE_IDLE",
     "VM_STATE_PAUSED",
     "VM_STATE_RUNNING",
@@ -43,6 +45,7 @@ __all__ = [
     "UnraidAuthenticationError",
     "UnraidConnectionError",
     "UnraidTimeoutError",
+    "is_monitorable_interface",
 ]
 
 # =============================================================================
@@ -105,3 +108,21 @@ WS_REFRESH_DEBOUNCE_SECONDS: Final = 10  # seconds
 # Repair Issue IDs
 # =============================================================================
 REPAIR_AUTH_FAILED: Final = "auth_failed"
+
+# =============================================================================
+# Network Interface Filters
+# =============================================================================
+# Only physical NICs, bonds, and user-configured bridges get entities —
+# Unraid names these ethN, bondN, brN/wlanN (plus VLAN sub-interfaces like
+# br0.5). Everything else is auto-generated plumbing that churns constantly
+# and carries no dashboard value: per-container veth pairs, VM vnet/tap
+# devices, loopback, and Docker/libvirt-created bridges and shims
+# (br-<hash>, docker0, shim-br0, virbr0).
+MONITORABLE_INTERFACE_RE: Final = re.compile(r"^(?:eth|bond|br|wlan)\d+(?:\.\d+)?$")
+
+
+def is_monitorable_interface(name: str | None) -> bool:
+    """Return True if the interface should get entities."""
+    if not name:
+        return False
+    return MONITORABLE_INTERFACE_RE.match(name) is not None

--- a/custom_components/unraid/coordinator.py
+++ b/custom_components/unraid/coordinator.py
@@ -36,11 +36,13 @@ from unraid_api.models import (
     Cloud,
     Connect,
     DockerContainer,
+    InfoNetworkInterface,
     Network,
     NetworkMetrics,
     NotificationOverview,
     ParityCheck,
     ParityHistoryEntry,
+    PluginInstallOperation,
     Registration,
     RemoteAccess,
     Service,
@@ -76,6 +78,8 @@ class UnraidSystemData:
     notifications_unread: int = 0
     mover_active: bool | None = None
     network_metrics: list[NetworkMetrics] = field(default_factory=list)
+    network_interfaces: list[InfoNetworkInterface] = field(default_factory=list)
+    plugin_operations: list[PluginInstallOperation] = field(default_factory=list)
 
 
 @dataclass(frozen=True)
@@ -195,6 +199,12 @@ class UnraidSystemCoordinator(TimestampDataUpdateCoordinator[UnraidSystemData]):
         # Cached network metrics list to keep the last known-good value across
         # failed optional queries.
         self._cached_network_metrics: list[NetworkMetrics] = []
+        # Cached network interfaces list to keep the last known-good value across
+        # failed optional queries.
+        self._cached_network_interfaces: list[InfoNetworkInterface] = []
+        # Cached plugin operations list to keep the last known-good value across
+        # failed optional queries.
+        self._cached_plugin_operations: list[PluginInstallOperation] = []
         # Status of the last optional query per category (True if succeeded,
         # False if failed).
         self._optional_query_status: dict[str, bool] = {
@@ -202,6 +212,8 @@ class UnraidSystemCoordinator(TimestampDataUpdateCoordinator[UnraidSystemData]):
             "vms": True,
             "ups_devices": True,
             "network_metrics": True,
+            "network_interfaces": True,
+            "plugin_operations": True,
         }
         self._event_listeners: dict[
             str, list[Callable[[UnraidNotificationEventData], None]]
@@ -631,6 +643,24 @@ class UnraidSystemCoordinator(TimestampDataUpdateCoordinator[UnraidSystemData]):
             _LOGGER.debug("Network metrics not available: %s", err)
             return None
 
+    async def _query_optional_network_interfaces(
+        self,
+    ) -> list[InfoNetworkInterface] | None:
+        """
+        Query per-interface network details (fails gracefully).
+
+        Returns:
+            list[InfoNetworkInterface] on success, or None if the query failed.
+
+        """
+        try:
+            return await self.api_client.typed_get_network_interfaces()
+        except UnraidAuthenticationError:
+            raise
+        except (UnraidAPIError, UnraidConnectionError, UnraidTimeoutError) as err:
+            _LOGGER.debug("Network interfaces not available: %s", err)
+            return None
+
     async def _query_optional_mover_status(self) -> bool | None:
         """Query mover active status (fails gracefully)."""
         try:
@@ -642,6 +672,27 @@ class UnraidSystemCoordinator(TimestampDataUpdateCoordinator[UnraidSystemData]):
             raise
         except (UnraidAPIError, UnraidConnectionError, UnraidTimeoutError) as err:
             _LOGGER.debug("Mover status data not available: %s", err)
+            return None
+
+    async def _query_optional_plugin_operations(
+        self,
+    ) -> list[PluginInstallOperation] | None:
+        """
+        Query in-progress plugin operations (fails gracefully).
+
+        Returns:
+            list[PluginInstallOperation] on success, or None if the query failed.
+
+        """
+        try:
+            return await self.api_client.get_plugin_install_operations()
+        except UnraidAuthenticationError:
+            raise
+        except (UnraidAPIError, UnraidConnectionError, UnraidTimeoutError) as err:
+            _LOGGER.debug("Plugin operations not available: %s", err)
+            return None
+        except Exception as err:  # noqa: BLE001
+            _LOGGER.debug("Plugin operations query failed: %s", err)
             return None
 
     async def async_request_docker_refresh(self) -> None:
@@ -675,6 +726,18 @@ class UnraidSystemCoordinator(TimestampDataUpdateCoordinator[UnraidSystemData]):
     async def async_update_all_containers(self) -> None:
         """Update every container with a pending image update (API 4.35+)."""
         await self.api_client.update_all_containers()
+
+    async def async_update_container_autostart(
+        self,
+        container_id: str,
+        *,
+        auto_start: bool,
+    ) -> None:
+        """Update container autostart configuration (API 4.36+ / unraid-api 1.13+)."""
+        await self.api_client.update_container_autostart(
+            [{"id": container_id, "autoStart": auto_start}]
+        )
+        await self.async_request_docker_refresh()
 
     async def async_refresh_docker_digests(self) -> None:
         """Force a re-check of remote image digests (the WebGUI 'check for updates')."""
@@ -716,6 +779,11 @@ class UnraidSystemCoordinator(TimestampDataUpdateCoordinator[UnraidSystemData]):
         """Delete all archived notifications."""
         await self.api_client.delete_all_notifications()
 
+    async def async_recalculate_notifications(self) -> None:
+        """Recalculate notification overview counts (unraid-api 1.13+)."""
+        await self.api_client.recalculate_notification_overview()
+        await self.async_request_refresh()
+
     async def _async_fetch_optional_system_data(
         self,
     ) -> tuple[
@@ -724,6 +792,8 @@ class UnraidSystemCoordinator(TimestampDataUpdateCoordinator[UnraidSystemData]):
         list[UPSDevice],
         bool | None,
         list[NetworkMetrics],
+        list[InfoNetworkInterface],
+        list[PluginInstallOperation],
     ]:
         """Fetch optional system data with throttling and cache fallback."""
         fetch_docker = self._force_docker_refresh or (
@@ -731,17 +801,20 @@ class UnraidSystemCoordinator(TimestampDataUpdateCoordinator[UnraidSystemData]):
         )
         if fetch_docker:
             (
-                docker_result,
-                vms_result,
-                ups_result,
-                mover_active,
-                network_result,
+                (docker_result, vms_result, ups_result, mover_active),
+                (network_result, network_ifaces_result, plugin_ops_result),
             ) = await asyncio.gather(
-                self._query_optional_docker(),
-                self._query_optional_vms(),
-                self._query_optional_ups(),
-                self._query_optional_mover_status(),
-                self._query_optional_network_metrics(),
+                asyncio.gather(
+                    self._query_optional_docker(),
+                    self._query_optional_vms(),
+                    self._query_optional_ups(),
+                    self._query_optional_mover_status(),
+                ),
+                asyncio.gather(
+                    self._query_optional_network_metrics(),
+                    self._query_optional_network_interfaces(),
+                    self._query_optional_plugin_operations(),
+                ),
             )
             self._optional_query_status["containers"] = docker_result is not None
             if docker_result is not None:
@@ -754,11 +827,15 @@ class UnraidSystemCoordinator(TimestampDataUpdateCoordinator[UnraidSystemData]):
                 ups_result,
                 mover_active,
                 network_result,
+                network_ifaces_result,
+                plugin_ops_result,
             ) = await asyncio.gather(
                 self._query_optional_vms(),
                 self._query_optional_ups(),
                 self._query_optional_mover_status(),
                 self._query_optional_network_metrics(),
+                self._query_optional_network_interfaces(),
+                self._query_optional_plugin_operations(),
             )
 
         self._optional_query_status["vms"] = vms_result is not None
@@ -773,12 +850,24 @@ class UnraidSystemCoordinator(TimestampDataUpdateCoordinator[UnraidSystemData]):
         if network_result is not None:
             self._cached_network_metrics = network_result
 
+        self._optional_query_status["network_interfaces"] = (
+            network_ifaces_result is not None
+        )
+        if network_ifaces_result is not None:
+            self._cached_network_interfaces = network_ifaces_result
+
+        self._optional_query_status["plugin_operations"] = plugin_ops_result is not None
+        if plugin_ops_result is not None:
+            self._cached_plugin_operations = plugin_ops_result
+
         return (
             self._cached_containers,
             self._cached_vms,
             self._cached_ups_devices,
             mover_active,
             self._cached_network_metrics,
+            self._cached_network_interfaces,
+            self._cached_plugin_operations,
         )
 
     @property
@@ -816,6 +905,8 @@ class UnraidSystemCoordinator(TimestampDataUpdateCoordinator[UnraidSystemData]):
                 ups_devices,
                 mover_active,
                 network_metrics,
+                network_interfaces,
+                plugin_operations,
             ) = await self._async_fetch_optional_system_data()
 
             # Log recovery if previously unavailable
@@ -852,6 +943,8 @@ class UnraidSystemCoordinator(TimestampDataUpdateCoordinator[UnraidSystemData]):
                 else 0,
                 mover_active=mover_active,
                 network_metrics=network_metrics,
+                network_interfaces=network_interfaces,
+                plugin_operations=plugin_operations,
             )
 
         except UnraidAuthenticationError as err:
@@ -966,6 +1059,11 @@ class UnraidStorageCoordinator(TimestampDataUpdateCoordinator[UnraidStorageData]
         """Spin down a disk."""
         await self.api_client.spin_down_disk(disk_id)
 
+    async def async_clear_disk_statistics(self, disk_id: str) -> None:
+        """Clear read, write, and error statistics for an array disk."""
+        await self.api_client.clear_array_disk_statistics(disk_id)
+        await self.async_request_refresh()
+
     async def _async_update_data(self) -> UnraidStorageData:
         """
         Fetch storage data from Unraid server using library typed methods.
@@ -1063,7 +1161,7 @@ class UnraidInfraCoordinator(TimestampDataUpdateCoordinator[UnraidInfraData]):
         self._previously_unavailable = False
 
     async def _query_optional_services(self) -> list[Service]:
-        """Query services (fails gracefully)."""
+        """Query services status (fails gracefully)."""
         try:
             return await self.api_client.typed_get_services()
         except UnraidAuthenticationError:
@@ -1083,7 +1181,7 @@ class UnraidInfraCoordinator(TimestampDataUpdateCoordinator[UnraidInfraData]):
             return None
 
     async def _query_optional_cloud(self) -> Cloud | None:
-        """Query cloud status (fails gracefully)."""
+        """Query Unraid Cloud connection (fails gracefully)."""
         try:
             return await self.api_client.typed_get_cloud()
         except UnraidAuthenticationError:
@@ -1093,7 +1191,7 @@ class UnraidInfraCoordinator(TimestampDataUpdateCoordinator[UnraidInfraData]):
             return None
 
     async def _query_optional_connect(self) -> Connect | None:
-        """Query connect status (fails gracefully)."""
+        """Query Unraid Connect plugin info (fails gracefully)."""
         try:
             return await self.api_client.typed_get_connect()
         except UnraidAuthenticationError:

--- a/custom_components/unraid/coordinator.py
+++ b/custom_components/unraid/coordinator.py
@@ -733,7 +733,7 @@ class UnraidSystemCoordinator(TimestampDataUpdateCoordinator[UnraidSystemData]):
         *,
         auto_start: bool,
     ) -> None:
-        """Update container autostart configuration (API 4.36+ / unraid-api 1.13+)."""
+        """Update container autostart configuration (API 4.37.0+ / unraid-api 1.13+)."""
         await self.api_client.update_container_autostart(
             [{"id": container_id, "autoStart": auto_start}]
         )

--- a/custom_components/unraid/coordinator.py
+++ b/custom_components/unraid/coordinator.py
@@ -1125,25 +1125,9 @@ class UnraidInfraCoordinator(TimestampDataUpdateCoordinator[UnraidInfraData]):
     async def _query_installed_plugins(self) -> list[str]:
         """Query installed Unraid plugin filenames (fails gracefully)."""
         try:
-            result = await self.api_client.query("query { installedUnraidPlugins }")
-
-            payload: dict[str, Any] | None = None
-            if isinstance(result, dict):
-                data = result.get("data")
-                payload = data if isinstance(data, dict) else result
-            else:
-                data_attr = getattr(result, "data", None)
-                if isinstance(data_attr, dict):
-                    payload = data_attr
-
-            if payload is None:
-                return []
-
-            plugins = payload.get("installedUnraidPlugins", [])
-
+            plugins = await self.api_client.get_installed_unraid_plugins()
             if not isinstance(plugins, list):
                 return []
-
             return [str(plugin) for plugin in plugins if plugin is not None]
         except UnraidAuthenticationError:
             raise

--- a/custom_components/unraid/entity.py
+++ b/custom_components/unraid/entity.py
@@ -202,7 +202,7 @@ class UnraidEntity[CoordinatorT: DataUpdateCoordinator[Any] = UnraidCoordinator]
 
 def async_add_dynamic_resource_entities[ResourceT](
     *,
-    coordinator: UnraidSystemCoordinator,
+    coordinator: UnraidCoordinator,
     async_add_entities: Callable[[list[Any]], None],
     get_resources: Callable[[], list[ResourceT]],
     get_key: Callable[[ResourceT], str],

--- a/custom_components/unraid/icons.json
+++ b/custom_components/unraid/icons.json
@@ -192,6 +192,12 @@
       },
       "network_interface_tx": {
         "default": "mdi:upload-network"
+      },
+      "network_interface_speed": {
+        "default": "mdi:speedometer"
+      },
+      "network_interface_ip": {
+        "default": "mdi:ip-network"
       }
     },
     "binary_sensor": {
@@ -248,11 +254,20 @@
       },
       "filesystems_unmountable": {
         "default": "mdi:harddisk-remove"
+      },
+      "network_interface_link": {
+        "default": "mdi:ethernet"
+      },
+      "plugin_installing": {
+        "default": "mdi:progress-download"
       }
     },
     "switch": {
       "docker_container": {
         "default": "mdi:docker"
+      },
+      "docker_container_autostart": {
+        "default": "mdi:play-box-multiple"
       },
       "virtual_machine": {
         "default": "mdi:desktop-tower"
@@ -306,6 +321,12 @@
       },
       "check_container_updates": {
         "default": "mdi:package-down"
+      },
+      "disk_clear_statistics": {
+        "default": "mdi:broom"
+      },
+      "recalculate_notifications": {
+        "default": "mdi:bell-badge-outline"
       }
     },
     "update": {

--- a/custom_components/unraid/manifest.json
+++ b/custom_components/unraid/manifest.json
@@ -8,7 +8,7 @@
   "homekit": {},
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/ruaan-deysel/ha-unraid/issues",
-  "requirements": ["unraid-api>=1.13.0"],
+  "requirements": ["unraid-api>=1.13.1"],
   "ssdp": [],
   "version": "2026.9.0",
   "zeroconf": []

--- a/custom_components/unraid/manifest.json
+++ b/custom_components/unraid/manifest.json
@@ -10,6 +10,6 @@
   "issue_tracker": "https://github.com/ruaan-deysel/ha-unraid/issues",
   "requirements": ["unraid-api>=1.13.1"],
   "ssdp": [],
-  "version": "2026.9.0",
+  "version": "2026.9.1",
   "zeroconf": []
 }

--- a/custom_components/unraid/manifest.json
+++ b/custom_components/unraid/manifest.json
@@ -8,7 +8,7 @@
   "homekit": {},
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/ruaan-deysel/ha-unraid/issues",
-  "requirements": ["unraid-api>=1.12.0"],
+  "requirements": ["unraid-api>=1.13.0"],
   "ssdp": [],
   "version": "2026.9.0",
   "zeroconf": []

--- a/custom_components/unraid/sensor.py
+++ b/custom_components/unraid/sensor.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import logging
-import re
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
@@ -2619,21 +2618,6 @@ class DockerTotalMemoryBytesSensor(
 # Network Interface Sensors (metrics.network, Unraid API 4.35+)
 # =============================================================================
 
-# Only physical NICs, bonds, and user-configured bridges get entities —
-# Unraid names these ethN, bondN, brN/wlanN (plus VLAN sub-interfaces like
-# br0.5). Everything else is auto-generated plumbing that churns constantly
-# and carries no dashboard value: per-container veth pairs, VM vnet/tap
-# devices, loopback, and Docker/libvirt-created bridges and shims
-# (br-<hash>, docker0, shim-br0, virbr0).
-_MONITORABLE_INTERFACE_RE = re.compile(r"^(?:eth|bond|br|wlan)\d+(?:\.\d+)?$")
-
-
-def _is_monitorable_interface(name: str | None) -> bool:
-    """Return True if the interface should get sensor entities."""
-    if not name:
-        return False
-    return _MONITORABLE_INTERFACE_RE.match(name) is not None
-
 
 class NetworkInterfaceSensorBase(UnraidSensorEntity[UnraidSystemCoordinator]):
     """
@@ -3600,7 +3584,7 @@ async def async_setup_entry(
         interface_name = registry_entry.unique_id.removeprefix(
             network_uid_prefix
         ).rsplit("_", 1)[0]
-        if not _is_monitorable_interface(interface_name):
+        if not is_monitorable_interface(interface_name):
             _LOGGER.debug(
                 "Removing sensor for non-monitorable interface %s (%s)",
                 interface_name,
@@ -3623,7 +3607,7 @@ async def async_setup_entry(
                     else []
                 )
                 if interface.name is not None
-                and _is_monitorable_interface(interface.name)
+                and is_monitorable_interface(interface.name)
             ],
             get_key=lambda interface: interface.name or "",
             create_entities=lambda interface: [

--- a/custom_components/unraid/sensor.py
+++ b/custom_components/unraid/sensor.py
@@ -30,6 +30,7 @@ from .const import (
     CONF_UPS_NOMINAL_POWER,
     DEFAULT_UPS_CAPACITY_VA,
     DEFAULT_UPS_NOMINAL_POWER,
+    is_monitorable_interface,
 )
 from .coordinator import (
     UnraidInfraCoordinator,
@@ -47,6 +48,7 @@ if TYPE_CHECKING:
     from unraid_api.models import (
         ArrayDisk,
         DockerContainerStats,
+        InfoNetworkInterface,
         NetworkMetrics,
         ParityHistoryEntry,
         Share,
@@ -2779,6 +2781,141 @@ class NetworkInterfaceTxSensor(NetworkInterfaceSensorBase):
         return attrs
 
 
+class NetworkInterfaceSpeedSensor(UnraidSensorEntity[UnraidSystemCoordinator]):
+    """Network interface negotiated link speed sensor."""
+
+    _attr_device_class = SensorDeviceClass.DATA_RATE
+    _attr_native_unit_of_measurement = UnitOfDataRate.MEGABITS_PER_SECOND
+    _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_translation_key = "network_interface_speed"
+
+    def __init__(
+        self,
+        coordinator: UnraidSystemCoordinator,
+        server_uuid: str,
+        server_name: str,
+        interface_name: str,
+        server_info: dict | None = None,
+    ) -> None:
+        """Initialize network interface speed sensor."""
+        self._interface_name = interface_name
+        super().__init__(
+            coordinator=coordinator,
+            server_uuid=server_uuid,
+            server_name=server_name,
+            resource_id=f"network_{interface_name}_speed",
+            name=f"Network {interface_name} Speed",
+            server_info=server_info,
+        )
+        self._attr_translation_placeholders = {"name": interface_name}
+
+    def _get_interface(self) -> InfoNetworkInterface | None:
+        """Look up this interface in the current coordinator data."""
+        data: UnraidSystemData | None = self.coordinator.data
+        if data is None:
+            return None
+        for interface in data.network_interfaces:
+            if interface.name == self._interface_name:
+                return interface
+        return None
+
+    @property
+    def native_value(self) -> int | None:
+        """Return negotiated link speed in Mbps."""
+        interface = self._get_interface()
+        if interface is None or interface.speed is None:
+            return None
+        return interface.speed
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return duplex and operational state."""
+        interface = self._get_interface()
+        if interface is None:
+            return {}
+        attrs: dict[str, Any] = {}
+        if interface.duplex:
+            attrs["duplex"] = interface.duplex
+        if interface.operstate:
+            attrs["operstate"] = interface.operstate
+        return attrs
+
+
+class NetworkInterfaceIpSensor(UnraidSensorEntity[UnraidSystemCoordinator]):
+    """Network interface IP address diagnostic sensor."""
+
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_translation_key = "network_interface_ip"
+
+    def __init__(
+        self,
+        coordinator: UnraidSystemCoordinator,
+        server_uuid: str,
+        server_name: str,
+        interface_name: str,
+        server_info: dict | None = None,
+    ) -> None:
+        """Initialize network interface IP sensor."""
+        self._interface_name = interface_name
+        super().__init__(
+            coordinator=coordinator,
+            server_uuid=server_uuid,
+            server_name=server_name,
+            resource_id=f"network_{interface_name}_ip",
+            name=f"Network {interface_name} IP",
+            server_info=server_info,
+        )
+        self._attr_translation_placeholders = {"name": interface_name}
+
+    def _get_interface(self) -> InfoNetworkInterface | None:
+        """Look up this interface in the current coordinator data."""
+        data: UnraidSystemData | None = self.coordinator.data
+        if data is None:
+            return None
+        for interface in data.network_interfaces:
+            if interface.name == self._interface_name:
+                return interface
+        return None
+
+    @property
+    def native_value(self) -> str | None:
+        """Return primary IP address."""
+        interface = self._get_interface()
+        if interface is None or not interface.ipAddress:
+            return None
+        return interface.ipAddress
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return full network addressing attributes."""
+        interface = self._get_interface()
+        if interface is None:
+            return {}
+        attrs: dict[str, Any] = {}
+        if interface.macAddress:
+            attrs["mac_address"] = interface.macAddress
+        if interface.netmask:
+            attrs["netmask"] = interface.netmask
+        if interface.gateway:
+            attrs["gateway"] = interface.gateway
+        if interface.ipv4Addresses:
+            attrs["ipv4_addresses"] = [
+                {"address": addr.address, "netmask": addr.netmask}
+                for addr in interface.ipv4Addresses
+                if addr.address
+            ]
+        if interface.ipv6Address:
+            attrs["ipv6_address"] = interface.ipv6Address
+        if interface.ipv6Addresses:
+            attrs["ipv6_addresses"] = [
+                {"address": addr.address, "prefix_length": addr.prefixLength}
+                for addr in interface.ipv6Addresses
+                if addr.address
+            ]
+        return attrs
+
+
 # =============================================================================
 # Parity Speed Sensor
 # =============================================================================
@@ -3501,6 +3638,40 @@ async def async_setup_entry(
                     server_uuid,
                     server_name,
                     interface.name or "",
+                ),
+            ],
+        )
+    )
+
+    # Network interface speed and IP sensors (Unraid API 4.35+ / unraid-api 1.13+)
+    entry.async_on_unload(
+        async_add_dynamic_resource_entities(
+            coordinator=system_coordinator,
+            async_add_entities=async_add_entities,
+            get_resources=lambda: [
+                iface
+                for iface in (
+                    system_coordinator.data.network_interfaces
+                    if system_coordinator.data
+                    else []
+                )
+                if iface.name and is_monitorable_interface(iface.name)
+            ],
+            get_key=lambda iface: iface.name or "",
+            create_entities=lambda iface: [
+                NetworkInterfaceSpeedSensor(
+                    system_coordinator,
+                    server_uuid,
+                    server_name,
+                    iface.name or "",
+                    server_info,
+                ),
+                NetworkInterfaceIpSensor(
+                    system_coordinator,
+                    server_uuid,
+                    server_name,
+                    iface.name or "",
+                    server_info,
                 ),
             ],
         )

--- a/custom_components/unraid/strings.json
+++ b/custom_components/unraid/strings.json
@@ -102,6 +102,18 @@
     "container_restart_failed": {
       "message": "Failed to restart container {name}: {error}"
     },
+    "container_autostart_failed": {
+      "message": "Failed to update autostart for container {name}: {error}"
+    },
+    "container_not_found": {
+      "message": "Container {name} not found"
+    },
+    "clear_disk_stats_failed": {
+      "message": "Failed to clear statistics for disk {name}: {error}"
+    },
+    "recalculate_notifications_failed": {
+      "message": "Failed to recalculate notification overview: {error}"
+    },
     "vm_start_failed": {
       "message": "Failed to start VM {name}: {error}"
     },
@@ -359,6 +371,12 @@
       },
       "network_interface_tx": {
         "name": "Network {name} outbound"
+      },
+      "network_interface_speed": {
+        "name": "Network {name} speed"
+      },
+      "network_interface_ip": {
+        "name": "Network {name} IP address"
       }
     },
     "binary_sensor": {
@@ -415,6 +433,12 @@
       },
       "filesystems_unmountable": {
         "name": "Filesystems unmountable"
+      },
+      "network_interface_link": {
+        "name": "Network {name} link"
+      },
+      "plugin_installing": {
+        "name": "Plugin installation in progress"
       }
     },
     "switch": {
@@ -429,6 +453,9 @@
       },
       "docker_container": {
         "name": "Container {name}"
+      },
+      "docker_container_autostart": {
+        "name": "Container {name} autostart"
       },
       "virtual_machine": {
         "name": "VM {name}"
@@ -473,6 +500,12 @@
       },
       "check_container_updates": {
         "name": "Check container updates"
+      },
+      "disk_clear_statistics": {
+        "name": "Disk {name} clear statistics"
+      },
+      "recalculate_notifications": {
+        "name": "Recalculate notifications"
       }
     },
     "update": {

--- a/custom_components/unraid/switch.py
+++ b/custom_components/unraid/switch.py
@@ -225,6 +225,131 @@ class DockerContainerSwitch(UnraidSwitchEntity[UnraidSystemCoordinator]):
         await self.coordinator.async_request_docker_refresh()
 
 
+class DockerContainerAutostartSwitch(UnraidSwitchEntity[UnraidSystemCoordinator]):
+    """Docker container autostart configuration switch."""
+
+    _attr_translation_key = "docker_container_autostart"
+    _attr_entity_category = EntityCategory.CONFIG
+
+    def __init__(
+        self,
+        coordinator: UnraidSystemCoordinator,
+        server_uuid: str,
+        server_name: str,
+        container: DockerContainer,
+    ) -> None:
+        """Initialize docker container autostart switch."""
+        self._container_name = container.name.lstrip("/")
+        self._container_id = container.id
+        self._cached_container: DockerContainer | None = None
+        self._cache_data: UnraidSystemData | None = None
+        super().__init__(
+            coordinator=coordinator,
+            server_uuid=server_uuid,
+            server_name=server_name,
+            resource_id=f"container_autostart_{self._container_name}",
+            name=f"Container {self._container_name} autostart",
+        )
+        self._attr_translation_placeholders = {"name": self._container_name}
+
+    def _get_container(self) -> DockerContainer | None:
+        """Get current container from coordinator data with caching."""
+        data: UnraidSystemData | None = self.coordinator.data
+        if data is None:
+            return None
+
+        if data is self._cache_data and self._cached_container is not None:
+            return self._cached_container
+
+        container_map = {c.name.lstrip("/"): c for c in data.containers}
+        self._cached_container = container_map.get(self._container_name)
+        self._cache_data = data
+
+        if self._cached_container is not None:
+            self._container_id = self._cached_container.id
+
+        return self._cached_container
+
+    @property
+    def is_on(self) -> bool:
+        """Return True if container autostart is enabled."""
+        container = self._get_container()
+        if container is None or container.autoStart is None:
+            return False
+        return bool(container.autoStart)
+
+    @property
+    def available(self) -> bool:
+        """Return True if coordinator is available and container exists."""
+        return super().available and self._get_container() is not None
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Enable container autostart."""
+        container = self._get_container()
+        if container is None:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="container_not_found",
+                translation_placeholders={"name": self._container_name},
+            )
+        try:
+            await self.coordinator.async_update_container_autostart(
+                self._container_id, auto_start=True
+            )
+            _LOGGER.debug(
+                "Enabled autostart for container %s (%s)",
+                self._container_name,
+                self._container_id,
+            )
+        except UnraidAPIError as err:
+            _LOGGER.error(
+                "Failed to enable autostart for container %s: %s",
+                self._container_name,
+                err,
+            )
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="container_autostart_failed",
+                translation_placeholders={
+                    "name": self._container_name,
+                    "error": str(err),
+                },
+            ) from err
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Disable container autostart."""
+        container = self._get_container()
+        if container is None:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="container_not_found",
+                translation_placeholders={"name": self._container_name},
+            )
+        try:
+            await self.coordinator.async_update_container_autostart(
+                self._container_id, auto_start=False
+            )
+            _LOGGER.debug(
+                "Disabled autostart for container %s (%s)",
+                self._container_name,
+                self._container_id,
+            )
+        except UnraidAPIError as err:
+            _LOGGER.error(
+                "Failed to disable autostart for container %s: %s",
+                self._container_name,
+                err,
+            )
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="container_autostart_failed",
+                translation_placeholders={
+                    "name": self._container_name,
+                    "error": str(err),
+                },
+            ) from err
+
+
 class VirtualMachineSwitch(UnraidSwitchEntity[UnraidSystemCoordinator]):
     """Virtual machine control switch."""
 
@@ -725,7 +850,13 @@ async def async_setup_entry(
                     server_uuid,
                     server_name,
                     container,
-                )
+                ),
+                DockerContainerAutostartSwitch(
+                    system_coordinator,
+                    server_uuid,
+                    server_name,
+                    container,
+                ),
             ],
         )
     )

--- a/custom_components/unraid/switch.py
+++ b/custom_components/unraid/switch.py
@@ -230,6 +230,7 @@ class DockerContainerAutostartSwitch(UnraidSwitchEntity[UnraidSystemCoordinator]
 
     _attr_translation_key = "docker_container_autostart"
     _attr_entity_category = EntityCategory.CONFIG
+    _attr_entity_registry_enabled_default = False
 
     def __init__(
         self,

--- a/custom_components/unraid/translations/en.json
+++ b/custom_components/unraid/translations/en.json
@@ -102,6 +102,18 @@
     "container_restart_failed": {
       "message": "Failed to restart container {name}: {error}"
     },
+    "container_autostart_failed": {
+      "message": "Failed to update autostart for container {name}: {error}"
+    },
+    "container_not_found": {
+      "message": "Container {name} not found"
+    },
+    "clear_disk_stats_failed": {
+      "message": "Failed to clear statistics for disk {name}: {error}"
+    },
+    "recalculate_notifications_failed": {
+      "message": "Failed to recalculate notification overview: {error}"
+    },
     "vm_start_failed": {
       "message": "Failed to start VM {name}: {error}"
     },
@@ -359,6 +371,12 @@
       },
       "network_interface_tx": {
         "name": "Network {name} outbound"
+      },
+      "network_interface_speed": {
+        "name": "Network {name} speed"
+      },
+      "network_interface_ip": {
+        "name": "Network {name} IP address"
       }
     },
     "binary_sensor": {
@@ -415,6 +433,12 @@
       },
       "filesystems_unmountable": {
         "name": "Filesystems unmountable"
+      },
+      "network_interface_link": {
+        "name": "Network {name} link"
+      },
+      "plugin_installing": {
+        "name": "Plugin installation in progress"
       }
     },
     "switch": {
@@ -429,6 +453,9 @@
       },
       "docker_container": {
         "name": "Container {name}"
+      },
+      "docker_container_autostart": {
+        "name": "Container {name} autostart"
       },
       "virtual_machine": {
         "name": "VM {name}"
@@ -473,6 +500,12 @@
       },
       "check_container_updates": {
         "name": "Check container updates"
+      },
+      "disk_clear_statistics": {
+        "name": "Disk {name} clear statistics"
+      },
+      "recalculate_notifications": {
+        "name": "Recalculate notifications"
       }
     },
     "update": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "homeassistant>=2026.5.0",
     "aiohttp>=3.14.3",
     "pydantic>=2.13.4",
-    "unraid-api>=1.12.1",
+    "unraid-api>=1.13.0",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "homeassistant>=2026.5.0",
     "aiohttp>=3.14.3",
     "pydantic>=2.13.4",
-    "unraid-api>=1.13.0",
+    "unraid-api>=1.13.1",
 ]
 
 [project.optional-dependencies]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -393,7 +393,10 @@ def create_mock_unraid_client(
     # Vars (returns Vars model)
     client.typed_get_vars = AsyncMock(return_value=vars_data)
 
-    # Installed plugins (returns list of plugin filenames via raw GraphQL query)
+    # Installed plugins (returns list of plugin filenames)
+    client.get_installed_unraid_plugins = AsyncMock(
+        return_value=installed_plugins or []
+    )
     client.query = AsyncMock(
         return_value={"installedUnraidPlugins": installed_plugins or []}
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,11 +19,13 @@ from unraid_api.models import (
     Cloud,
     Connect,
     DockerContainer,
+    InfoNetworkInterface,
     NetworkMetrics,
     NotificationOverview,
     NotificationOverviewCounts,
     ParityCheck,
     ParityHistoryEntry,
+    PluginInstallOperation,
     Registration,
     RemoteAccess,
     ServerInfo,
@@ -125,6 +127,8 @@ def make_system_data(
     temperature: TemperatureMetrics | None = None,
     mover_active: bool | None = None,
     network_metrics: list[NetworkMetrics] | None = None,
+    network_interfaces: list[InfoNetworkInterface] | None = None,
+    plugin_operations: list[PluginInstallOperation] | None = None,
 ) -> UnraidSystemData:
     """Create a UnraidSystemData instance for testing."""
     from datetime import datetime
@@ -168,6 +172,8 @@ def make_system_data(
         notifications_unread=notifications_unread,
         mover_active=mover_active,
         network_metrics=network_metrics or [],
+        network_interfaces=network_interfaces or [],
+        plugin_operations=plugin_operations or [],
     )
 
 
@@ -403,6 +409,21 @@ def create_mock_unraid_client(
 
     # Network (returns Network model)
     client.typed_get_network = AsyncMock(return_value=None)
+
+    # Network interfaces (returns list of InfoNetworkInterface)
+    client.typed_get_network_interfaces = AsyncMock(return_value=[])
+
+    # Container autostart mutation
+    client.update_container_autostart = AsyncMock(return_value=True)
+
+    # Disk statistics mutation
+    client.clear_array_disk_statistics = AsyncMock(return_value=True)
+
+    # Notification recalculate mutation
+    client.recalculate_notification_overview = AsyncMock(return_value=True)
+
+    # Plugin install operations query
+    client.get_plugin_install_operations = AsyncMock(return_value=[])
 
     return client
 

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -2207,14 +2207,19 @@ def test_network_interface_link_down_or_missing() -> None:
     )
     assert sensor.is_on is False
 
+    # When interface exists but operstate is empty
+    iface_empty = InfoNetworkInterface(id="eth0", name="eth0", operstate="")
+    coordinator.data = make_system_data(network_interfaces=[iface_empty])
+    assert sensor.is_on is False
+
     # When interface is missing from list
     coordinator.data = make_system_data(network_interfaces=[])
-    assert sensor.is_on is False
+    assert sensor.is_on is None
     assert sensor.extra_state_attributes == {}
 
     # When coordinator data is None
     coordinator.data = None
-    assert sensor.is_on is False
+    assert sensor.is_on is None
     assert sensor.extra_state_attributes == {}
 
 
@@ -2280,5 +2285,5 @@ def test_plugin_installing_binary_sensor_idle() -> None:
 
     # When coordinator data is None
     coordinator.data = None
-    assert sensor.is_on is False
+    assert sensor.is_on is None
     assert sensor.extra_state_attributes == {}

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -19,7 +19,9 @@ from unraid_api.models import (
     Cloud,
     CloudResponse,
     DockerContainer,
+    InfoNetworkInterface,
     ParityCheck,
+    PluginInstallOperation,
     RemoteAccess,
     Service,
     ServiceUptime,
@@ -41,10 +43,12 @@ from custom_components.unraid.binary_sensor import (
     DisksMissingBinarySensor,
     FilesystemsUnmountableBinarySensor,
     MoverActiveBinarySensor,
+    NetworkInterfaceLinkBinarySensor,
     ParityCheckPausedBinarySensor,
     ParityCheckRunningBinarySensor,
     ParityStatusBinarySensor,
     ParityValidBinarySensor,
+    PluginInstallingBinarySensor,
     RemoteAccessBinarySensor,
     SafeModeBinarySensor,
     ServiceBinarySensor,
@@ -2136,3 +2140,145 @@ def test_parity_check_paused_none_field() -> None:
         server_name="tower",
     )
     assert sensor.is_on is False
+
+
+# =============================================================================
+# NetworkInterfaceLinkBinarySensor Tests
+# =============================================================================
+
+
+def test_network_interface_link_properties_and_state() -> None:
+    """Test NetworkInterfaceLinkBinarySensor properties, state, and attributes."""
+    iface = InfoNetworkInterface(
+        id="eth0",
+        name="eth0",
+        operstate="up",
+        macAddress="00:11:22:33:44:55",
+        ipAddress="192.168.1.50",
+        duplex="full",
+        mtu=1500,
+        speed=1000,
+        vlanId=None,
+        virtual=False,
+        internal=False,
+        protocol="tcp",
+        type="ethernet",
+    )
+    coordinator = MagicMock(spec=UnraidSystemCoordinator)
+    coordinator.data = make_system_data(network_interfaces=[iface])
+    coordinator.last_update_success = True
+
+    sensor = NetworkInterfaceLinkBinarySensor(
+        coordinator=coordinator,
+        server_uuid="uuid-1",
+        server_name="tower",
+        interface_name="eth0",
+    )
+
+    assert sensor.translation_key == "network_interface_link"
+    assert sensor.translation_placeholders == {"name": "eth0"}
+    assert sensor.unique_id == "uuid-1_network_eth0_link"
+    assert sensor.device_class == BinarySensorDeviceClass.CONNECTIVITY
+    assert sensor.is_on is True
+
+    attrs = sensor.extra_state_attributes
+    assert attrs["mac_address"] == "00:11:22:33:44:55"
+    assert attrs["ip_address"] == "192.168.1.50"
+    assert attrs["duplex"] == "full"
+    assert attrs["mtu"] == 1500
+    assert attrs["speed_mbps"] == 1000
+    assert attrs["virtual"] is False
+    assert attrs["internal"] is False
+    assert attrs["protocol"] == "tcp"
+    assert attrs["interface_type"] == "ethernet"
+
+
+def test_network_interface_link_down_or_missing() -> None:
+    """Test NetworkInterfaceLinkBinarySensor when down or missing from coordinator."""
+    iface_down = InfoNetworkInterface(id="eth0", name="eth0", operstate="down")
+    coordinator = MagicMock(spec=UnraidSystemCoordinator)
+    coordinator.data = make_system_data(network_interfaces=[iface_down])
+
+    sensor = NetworkInterfaceLinkBinarySensor(
+        coordinator=coordinator,
+        server_uuid="uuid-1",
+        server_name="tower",
+        interface_name="eth0",
+    )
+    assert sensor.is_on is False
+
+    # When interface is missing from list
+    coordinator.data = make_system_data(network_interfaces=[])
+    assert sensor.is_on is False
+    assert sensor.extra_state_attributes == {}
+
+    # When coordinator data is None
+    coordinator.data = None
+    assert sensor.is_on is False
+    assert sensor.extra_state_attributes == {}
+
+
+# =============================================================================
+# PluginInstallingBinarySensor Tests
+# =============================================================================
+
+
+def test_plugin_installing_binary_sensor_active() -> None:
+    """Test PluginInstallingBinarySensor when an operation is running."""
+    op1 = PluginInstallOperation(
+        id="op-1",
+        name="community.applications.plg",
+        status="RUNNING",
+        url="https://example.com/ca.plg",
+    )
+    coordinator = MagicMock(spec=UnraidSystemCoordinator)
+    coordinator.data = make_system_data(plugin_operations=[op1])
+    coordinator.last_update_success = True
+
+    sensor = PluginInstallingBinarySensor(
+        coordinator=coordinator,
+        server_uuid="uuid-1",
+        server_name="tower",
+    )
+
+    assert sensor.translation_key == "plugin_installing"
+    assert sensor.unique_id == "uuid-1_plugin_installing"
+    assert sensor.device_class == BinarySensorDeviceClass.RUNNING
+    assert sensor.is_on is True
+
+    attrs = sensor.extra_state_attributes
+    assert attrs["active_count"] == 1
+    assert attrs["total_operations"] == 1
+    assert attrs["active_operations"][0]["name"] == "community.applications.plg"
+
+
+def test_plugin_installing_binary_sensor_idle() -> None:
+    """Test PluginInstallingBinarySensor when no operations are active."""
+    op_done = PluginInstallOperation(
+        id="op-2",
+        name="unassigned.devices.plg",
+        status="COMPLETED",
+        url="https://example.com/ud.plg",
+    )
+    coordinator = MagicMock(spec=UnraidSystemCoordinator)
+    coordinator.data = make_system_data(plugin_operations=[op_done])
+
+    sensor = PluginInstallingBinarySensor(
+        coordinator=coordinator,
+        server_uuid="uuid-1",
+        server_name="tower",
+    )
+    assert sensor.is_on is False
+    attrs = sensor.extra_state_attributes
+    assert attrs["active_count"] == 0
+    assert attrs["total_operations"] == 1
+
+    # When plugin_operations is empty
+    coordinator.data = make_system_data(plugin_operations=[])
+    assert sensor.is_on is False
+    assert sensor.extra_state_attributes["active_count"] == 0
+
+    # When coordinator data is None
+    coordinator.data = None
+    assert sensor.is_on is False
+    assert sensor.extra_state_attributes == {}

--- a/tests/test_button.py
+++ b/tests/test_button.py
@@ -494,10 +494,13 @@ async def test_setup_entry_dynamic_clear_disk_statistics_buttons(hass):
     mock_api = MagicMock()
     disk1 = ArrayDisk(id="disk1", name="Disk 1")
     parity1 = ArrayDisk(id="parity", name="Parity")
+    boot_disk = ArrayDisk(id="boot", name="Flash")
 
     storage_coordinator = MagicMock()
     storage_coordinator.async_add_listener = MagicMock()
-    storage_coordinator.data = make_storage_data(disks=[disk1], parities=[parity1])
+    storage_coordinator.data = make_storage_data(
+        disks=[disk1], parities=[parity1], boot=boot_disk
+    )
 
     system_coordinator = MagicMock()
     system_coordinator.data = make_system_data()
@@ -525,6 +528,9 @@ async def test_setup_entry_dynamic_clear_disk_statistics_buttons(hass):
     assert {b.unique_id for b in disk_buttons} == {
         "test-uuid_disk_disk1_clear_statistics",
         "test-uuid_disk_parity_clear_statistics",
+    }
+    assert "test-uuid_disk_boot_clear_statistics" not in {
+        b.unique_id for b in disk_buttons
     }
 
 

--- a/tests/test_button.py
+++ b/tests/test_button.py
@@ -9,11 +9,13 @@ from unraid_api.exceptions import UnraidAPIError
 from custom_components.unraid.button import (
     ArchiveAllNotificationsButton,
     CheckContainerUpdatesButton,
+    ClearDiskStatisticsButton,
     DeleteAllArchivedNotificationsButton,
     DockerContainerRestartButton,
     ParityCheckPauseButton,
     ParityCheckResumeButton,
     ParityCheckStartCorrectionButton,
+    RecalculateNotificationsButton,
     UpdateAllContainersButton,
     VMForceStopButton,
     VMPauseButton,
@@ -244,14 +246,15 @@ async def test_setup_entry_creates_parity_buttons(hass):
 
     await async_setup_entry(hass, mock_entry, capture_entities)
 
-    # 3 parity + 2 notification + 2 server-wide docker update buttons
-    assert len(entities) == 7
+    # 3 parity + 3 notification + 2 server-wide docker update buttons
+    assert len(entities) == 8
     entity_types = [type(e).__name__ for e in entities]
     assert "ParityCheckStartCorrectionButton" in entity_types
     assert "ParityCheckPauseButton" in entity_types
     assert "ParityCheckResumeButton" in entity_types
     assert "ArchiveAllNotificationsButton" in entity_types
     assert "DeleteAllArchivedNotificationsButton" in entity_types
+    assert "RecalculateNotificationsButton" in entity_types
 
 
 @pytest.mark.asyncio
@@ -277,7 +280,7 @@ async def test_setup_entry_with_missing_server_uuid(hass):
     await async_setup_entry(hass, mock_entry, capture_entities)
 
     # Check that entities were created with "unknown" uuid
-    assert len(entities) == 7
+    assert len(entities) == 8
     assert entities[0].unique_id.startswith("unknown_")
 
 
@@ -303,8 +306,8 @@ async def test_setup_entry_uses_host_as_fallback_name(hass):
 
     await async_setup_entry(hass, mock_entry, capture_entities)
 
-    # Should still create 3 parity + 2 notification + 2 docker update buttons
-    assert len(entities) == 7
+    # Should still create 3 parity + 3 notification + 2 docker update buttons
+    assert len(entities) == 8
 
 
 # =============================================================================
@@ -443,8 +446,8 @@ async def test_setup_entry_creates_container_restart_buttons(hass):
 
     await async_setup_entry(hass, mock_entry, capture_entities)
 
-    # 3 parity + 2 notification + 2 container restart + 2 docker update = 9
-    assert len(entities) == 9
+    # 3 parity + 3 notification + 2 container restart + 2 docker update = 10
+    assert len(entities) == 10
     entity_types = [type(e).__name__ for e in entities]
     assert entity_types.count("DockerContainerRestartButton") == 2
     assert entity_types.count("CheckContainerUpdatesButton") == 1
@@ -477,8 +480,52 @@ async def test_setup_entry_no_containers(hass):
 
     await async_setup_entry(hass, mock_entry, capture_entities)
 
-    # 3 parity + 2 notification + 2 docker update buttons, no container buttons
-    assert len(entities) == 7
+    # 3 parity + 3 notification + 2 docker update buttons, no container buttons
+    assert len(entities) == 8
+
+
+@pytest.mark.asyncio
+async def test_setup_entry_dynamic_clear_disk_statistics_buttons(hass):
+    """Test dynamic registration of ClearDiskStatisticsButton for disks."""
+    from unraid_api.models import ArrayDisk
+
+    from tests.conftest import make_storage_data, make_system_data
+
+    mock_api = MagicMock()
+    disk1 = ArrayDisk(id="disk1", name="Disk 1")
+    parity1 = ArrayDisk(id="parity", name="Parity")
+
+    storage_coordinator = MagicMock()
+    storage_coordinator.async_add_listener = MagicMock()
+    storage_coordinator.data = make_storage_data(disks=[disk1], parities=[parity1])
+
+    system_coordinator = MagicMock()
+    system_coordinator.data = make_system_data()
+    system_coordinator.async_add_listener = MagicMock()
+
+    runtime_data = MagicMock()
+    runtime_data.api_client = mock_api
+    runtime_data.server_info = {"uuid": "test-uuid", "name": "Test Server"}
+    runtime_data.system_coordinator = system_coordinator
+    runtime_data.storage_coordinator = storage_coordinator
+
+    mock_entry = MagicMock()
+    mock_entry.runtime_data = runtime_data
+    mock_entry.data = {"host": "192.168.1.100"}
+
+    entities = []
+
+    def capture_entities(ents) -> None:
+        entities.extend(ents)
+
+    await async_setup_entry(hass, mock_entry, capture_entities)
+
+    disk_buttons = [e for e in entities if isinstance(e, ClearDiskStatisticsButton)]
+    assert len(disk_buttons) == 2
+    assert {b.unique_id for b in disk_buttons} == {
+        "test-uuid_disk_disk1_clear_statistics",
+        "test-uuid_disk_parity_clear_statistics",
+    }
 
 
 # =============================================================================
@@ -790,8 +837,8 @@ async def test_setup_entry_creates_vm_buttons(hass):
 
     await async_setup_entry(hass, mock_entry, capture_entities)
 
-    # 3 parity + 2 notification + 2 docker update + 2 VMs * 5 buttons each = 17
-    assert len(entities) == 17
+    # 3 parity + 3 notification + 2 docker update + 2 VMs * 5 buttons each = 18
+    assert len(entities) == 18
     entity_types = [type(e).__name__ for e in entities]
     assert entity_types.count("VMForceStopButton") == 2
     assert entity_types.count("VMRebootButton") == 2
@@ -837,9 +884,9 @@ async def test_setup_entry_creates_container_and_vm_buttons(hass):
 
     await async_setup_entry(hass, mock_entry, capture_entities)
 
-    # 3 parity + 2 notification + 1 container restart + 2 docker update
-    # + 1 VM * 5 buttons = 13
-    assert len(entities) == 13
+    # 3 parity + 3 notification + 1 container restart + 2 docker update
+    # + 1 VM * 5 buttons = 14
+    assert len(entities) == 14
     entity_types = [type(e).__name__ for e in entities]
     assert entity_types.count("DockerContainerRestartButton") == 1
     assert entity_types.count("CheckContainerUpdatesButton") == 1
@@ -1069,3 +1116,99 @@ async def test_check_container_updates_button_error(mock_coordinator, mock_serve
         await button.async_press()
     assert exc_info.value.translation_key == "check_container_updates_failed"
     mock_coordinator.async_request_docker_refresh.assert_not_called()
+
+
+# =============================================================================
+# RecalculateNotificationsButton Tests
+# =============================================================================
+
+
+@pytest.mark.asyncio
+async def test_recalculate_notifications_button_press(
+    mock_coordinator, mock_server_info
+):
+    """Test pressing recalculate notifications button calls coordinator method."""
+    mock_coordinator.async_recalculate_notifications = AsyncMock()
+
+    button = RecalculateNotificationsButton(
+        coordinator=mock_coordinator,
+        server_uuid="test-uuid",
+        server_name="Test Server",
+        server_info=mock_server_info,
+    )
+
+    assert button.translation_key == "recalculate_notifications"
+    assert button.unique_id == "test-uuid_recalculate_notifications"
+
+    await button.async_press()
+    mock_coordinator.async_recalculate_notifications.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_recalculate_notifications_button_error(
+    mock_coordinator, mock_server_info
+):
+    """Test recalculate notifications button error handling."""
+    mock_coordinator.async_recalculate_notifications = AsyncMock(
+        side_effect=UnraidAPIError("API failure")
+    )
+
+    button = RecalculateNotificationsButton(
+        coordinator=mock_coordinator,
+        server_uuid="test-uuid",
+        server_name="Test Server",
+        server_info=mock_server_info,
+    )
+
+    with pytest.raises(HomeAssistantError) as exc_info:
+        await button.async_press()
+    assert exc_info.value.translation_key == "recalculate_notifications_failed"
+
+
+# =============================================================================
+# ClearDiskStatisticsButton Tests
+# =============================================================================
+
+
+@pytest.mark.asyncio
+async def test_clear_disk_statistics_button_press(mock_coordinator, mock_server_info):
+    """Test pressing clear disk statistics button calls storage coordinator method."""
+    mock_coordinator.async_clear_disk_statistics = AsyncMock()
+
+    button = ClearDiskStatisticsButton(
+        coordinator=mock_coordinator,
+        server_uuid="test-uuid",
+        server_name="Test Server",
+        disk_id="disk1",
+        disk_name="Disk 1",
+        server_info=mock_server_info,
+    )
+
+    assert button.translation_key == "disk_clear_statistics"
+    assert button.translation_placeholders == {"name": "Disk 1"}
+    assert button.unique_id == "test-uuid_disk_disk1_clear_statistics"
+    assert button.entity_registry_enabled_default is False
+
+    await button.async_press()
+    mock_coordinator.async_clear_disk_statistics.assert_called_once_with("disk1")
+
+
+@pytest.mark.asyncio
+async def test_clear_disk_statistics_button_error(mock_coordinator, mock_server_info):
+    """Test clear disk statistics button error handling."""
+    mock_coordinator.async_clear_disk_statistics = AsyncMock(
+        side_effect=UnraidAPIError("API failure")
+    )
+
+    button = ClearDiskStatisticsButton(
+        coordinator=mock_coordinator,
+        server_uuid="test-uuid",
+        server_name="Test Server",
+        disk_id="disk1",
+        disk_name="Disk 1",
+        server_info=mock_server_info,
+    )
+
+    with pytest.raises(HomeAssistantError) as exc_info:
+        await button.async_press()
+    assert exc_info.value.translation_key == "clear_disk_stats_failed"

--- a/tests/test_cleanup.py
+++ b/tests/test_cleanup.py
@@ -111,6 +111,21 @@ class TestIsDynamicResourceId:
     def test_network_tx(self) -> None:
         assert _is_dynamic_resource_id("network_bond0_tx") is True
 
+    def test_network_link(self) -> None:
+        assert _is_dynamic_resource_id("network_eth0_link") is True
+
+    def test_network_speed(self) -> None:
+        assert _is_dynamic_resource_id("network_eth0_speed") is True
+
+    def test_network_ip(self) -> None:
+        assert _is_dynamic_resource_id("network_eth0_ip") is True
+
+    def test_container_autostart(self) -> None:
+        assert _is_dynamic_resource_id("container_autostart_myapp") is True
+
+    def test_disk_clear_statistics(self) -> None:
+        assert _is_dynamic_resource_id("disk_sda_clear_statistics") is True
+
     # ---- static patterns that MUST return False ----
 
     def test_cpu_usage(self) -> None:
@@ -172,6 +187,13 @@ class TestGetDynamicResourceCategory:
         assert _get_dynamic_resource_category("vm_switch_win") == "vms"
         assert _get_dynamic_resource_category("ups_apc_battery") == "ups_devices"
         assert _get_dynamic_resource_category("network_eth0_rx") == "network_metrics"
+        assert (
+            _get_dynamic_resource_category("network_eth0_link") == "network_interfaces"
+        )
+        assert (
+            _get_dynamic_resource_category("network_eth0_speed") == "network_interfaces"
+        )
+        assert _get_dynamic_resource_category("network_eth0_ip") == "network_interfaces"
         assert _get_dynamic_resource_category("disk_sda_temp") is None
         assert _get_dynamic_resource_category("container_updates_count") is None
         assert _get_dynamic_resource_category("network_access") is None
@@ -204,6 +226,7 @@ class TestBuildExpectedDynamicUniqueIds:
         result = build_expected_dynamic_unique_ids(_UUID, sys_data, stor_data)
 
         assert f"{_UUID}_container_switch_myapp" in result
+        assert f"{_UUID}_container_autostart_myapp" in result
         assert f"{_UUID}_container_restart_myapp" in result
         assert f"{_UUID}_container_myapp_cpu" in result
         assert f"{_UUID}_container_myapp_memory" in result
@@ -229,6 +252,21 @@ class TestBuildExpectedDynamicUniqueIds:
         assert f"{_UUID}_vm_pause_windows11" in result
         assert f"{_UUID}_vm_resume_windows11" in result
         assert f"{_UUID}_vm_reset_windows11" in result
+
+    def test_network_interface_info_ids(self) -> None:
+        from unraid_api.models import InfoNetworkInterface
+
+        iface = MagicMock(spec=InfoNetworkInterface)
+        iface.name = "eth0"
+        iface.id = "eth0"
+
+        sys_data = make_system_data(network_interfaces=[iface])
+        stor_data = make_storage_data()
+        result = build_expected_dynamic_unique_ids(_UUID, sys_data, stor_data)
+
+        assert f"{_UUID}_network_eth0_link" in result
+        assert f"{_UUID}_network_eth0_speed" in result
+        assert f"{_UUID}_network_eth0_ip" in result
 
     def test_single_ups(self) -> None:
         from unraid_api.models import UPSDevice
@@ -270,6 +308,7 @@ class TestBuildExpectedDynamicUniqueIds:
         assert f"{_UUID}_disk_sdb_usage" in result
         assert f"{_UUID}_disk_health_sdb" in result
         assert f"{_UUID}_disk_spin_sdb" in result
+        assert f"{_UUID}_disk_sdb_clear_statistics" in result
 
     def test_parity_disk_ids(self) -> None:
         from unraid_api.models import ArrayDisk

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -185,6 +185,11 @@ def mock_api_client():
     client.get_installed_unraid_plugins = AsyncMock(return_value=[])
     client.query = AsyncMock(return_value={"installedUnraidPlugins": []})
     client.typed_get_network = AsyncMock(return_value=None)
+    client.typed_get_network_interfaces = AsyncMock(return_value=[])
+    client.get_plugin_install_operations = AsyncMock(return_value=[])
+    client.update_container_autostart = AsyncMock(return_value=True)
+    client.clear_array_disk_statistics = AsyncMock(return_value=True)
+    client.recalculate_notification_overview = AsyncMock(return_value=True)
     client.typed_get_notifications = AsyncMock(return_value=[])
     client.close = AsyncMock()
     client.archive_all_notifications = AsyncMock(return_value={})
@@ -2762,3 +2767,116 @@ async def test_infra_update_connection_error_raises_update_failed(
 
     with pytest.raises(UpdateFailed):
         await coordinator._async_update_data()
+
+
+# =============================================================================
+# New 1.13.0 API Method Tests
+# =============================================================================
+
+
+@pytest.mark.asyncio
+async def test_system_coordinator_update_container_autostart(
+    hass, mock_api_client, mock_config_entry
+):
+    """Test updating container autostart mutation and refresh triggers."""
+    coordinator = _system_coordinator(hass, mock_api_client, mock_config_entry)
+    coordinator.async_request_docker_refresh = AsyncMock()
+
+    await coordinator.async_update_container_autostart("c1", auto_start=True)
+    mock_api_client.update_container_autostart.assert_called_once_with(
+        [{"id": "c1", "autoStart": True}]
+    )
+    coordinator.async_request_docker_refresh.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_system_coordinator_recalculate_notifications(
+    hass, mock_api_client, mock_config_entry
+):
+    """Test recalculate notification overview mutation and refresh triggers."""
+    coordinator = _system_coordinator(hass, mock_api_client, mock_config_entry)
+    coordinator.async_request_refresh = AsyncMock()
+
+    await coordinator.async_recalculate_notifications()
+    mock_api_client.recalculate_notification_overview.assert_called_once()
+    coordinator.async_request_refresh.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_storage_coordinator_clear_disk_statistics(
+    hass, mock_api_client, mock_config_entry
+):
+    """Test clear disk statistics mutation and refresh triggers."""
+    coordinator = _storage_coordinator(hass, mock_api_client, mock_config_entry)
+    coordinator.async_request_refresh = AsyncMock()
+
+    await coordinator.async_clear_disk_statistics("disk1")
+    mock_api_client.clear_array_disk_statistics.assert_called_once_with("disk1")
+    coordinator.async_request_refresh.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_system_coordinator_query_optional_network_interfaces(
+    hass, mock_api_client, mock_config_entry
+):
+    """Test optional network interfaces query with caching."""
+    from unraid_api.exceptions import UnraidAPIError
+    from unraid_api.models import InfoNetworkInterface
+
+    iface = InfoNetworkInterface(id="eth0", name="eth0", speed=1000)
+    mock_api_client.typed_get_network_interfaces = AsyncMock(return_value=[iface])
+    coordinator = _system_coordinator(hass, mock_api_client, mock_config_entry)
+
+    # Direct query succeeds
+    result = await coordinator._query_optional_network_interfaces()
+    assert result == [iface]
+
+    # Optional system data fetch updates cache
+    (
+        _,
+        _,
+        _,
+        _,
+        _,
+        ifaces,
+        _,
+    ) = await coordinator._async_fetch_optional_system_data()
+    assert ifaces == [iface]
+    assert coordinator._cached_network_interfaces == [iface]
+
+    # Subsequent error falls back to cache
+    mock_api_client.typed_get_network_interfaces = AsyncMock(
+        side_effect=UnraidAPIError("API failure")
+    )
+    (
+        _,
+        _,
+        _,
+        _,
+        _,
+        fallback_ifaces,
+        _,
+    ) = await coordinator._async_fetch_optional_system_data()
+    assert fallback_ifaces == [iface]
+
+
+@pytest.mark.asyncio
+async def test_system_coordinator_query_optional_plugin_operations(
+    hass, mock_api_client, mock_config_entry
+):
+    """Test optional plugin operations query in system coordinator."""
+    from unraid_api.models import PluginInstallOperation
+
+    op = PluginInstallOperation(id="op1", name="test.plg", status="RUNNING")
+    mock_api_client.get_plugin_install_operations = AsyncMock(return_value=[op])
+    coordinator = _system_coordinator(hass, mock_api_client, mock_config_entry)
+
+    result = await coordinator._query_optional_plugin_operations()
+    assert result == [op]
+
+    # Error handling returns None on failure
+    mock_api_client.get_plugin_install_operations = AsyncMock(
+        side_effect=Exception("API error")
+    )
+    fallback = await coordinator._query_optional_plugin_operations()
+    assert fallback is None

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -182,6 +182,7 @@ def mock_api_client():
     client.typed_get_connect = AsyncMock(return_value=None)
     client.typed_get_remote_access = AsyncMock(return_value=None)
     client.typed_get_vars = AsyncMock(return_value=None)
+    client.get_installed_unraid_plugins = AsyncMock(return_value=[])
     client.query = AsyncMock(return_value={"installedUnraidPlugins": []})
     client.typed_get_network = AsyncMock(return_value=None)
     client.typed_get_notifications = AsyncMock(return_value=[])
@@ -1074,7 +1075,7 @@ async def test_infra_coordinator_fetch_success(
     mock_api_client.typed_get_connect.assert_called_once()
     mock_api_client.typed_get_remote_access.assert_called_once()
     mock_api_client.typed_get_vars.assert_called_once()
-    mock_api_client.query.assert_called_once_with("query { installedUnraidPlugins }")
+    mock_api_client.get_installed_unraid_plugins.assert_called_once()
     mock_api_client.typed_get_network.assert_called_once()
 
 
@@ -2687,7 +2688,7 @@ async def test_storage_parity_history_auth_error_raises(
         "typed_get_remote_access",
         "typed_get_vars",
         "typed_get_network",
-        "query",
+        "get_installed_unraid_plugins",
     ],
 )
 async def test_infra_optional_queries_raise_auth_errors(
@@ -2702,7 +2703,7 @@ async def test_infra_optional_queries_raise_auth_errors(
         "typed_get_remote_access": "_query_optional_remote_access",
         "typed_get_vars": "_query_optional_vars",
         "typed_get_network": "_query_optional_network",
-        "query": "_query_installed_plugins",
+        "get_installed_unraid_plugins": "_query_installed_plugins",
     }
     setattr(
         mock_api_client,
@@ -2720,7 +2721,9 @@ async def test_infra_installed_plugins_api_error_returns_empty(
     hass, mock_api_client, mock_config_entry
 ):
     """Unraid API errors in the plugins query return an empty list."""
-    mock_api_client.query = AsyncMock(side_effect=UnraidAPIError("nope"))
+    mock_api_client.get_installed_unraid_plugins = AsyncMock(
+        side_effect=UnraidAPIError("nope")
+    )
     coordinator = _infra_coordinator(hass, mock_api_client, mock_config_entry)
 
     assert await coordinator._query_installed_plugins() == []
@@ -2730,18 +2733,18 @@ async def test_infra_installed_plugins_api_error_returns_empty(
 async def test_infra_installed_plugins_payload_shapes(
     hass, mock_api_client, mock_config_entry
 ):
-    """Plugins query handles dict payloads, data wrappers, and bad shapes."""
+    """Plugins query handles list payloads with None and bad shapes."""
     coordinator = _infra_coordinator(hass, mock_api_client, mock_config_entry)
 
-    mock_api_client.query = AsyncMock(
-        return_value={"data": {"installedUnraidPlugins": ["a", None, "b"]}}
+    mock_api_client.get_installed_unraid_plugins = AsyncMock(
+        return_value=["a", None, "b"]
     )
     assert await coordinator._query_installed_plugins() == ["a", "b"]
 
-    mock_api_client.query = AsyncMock(return_value={"installedUnraidPlugins": "bad"})
+    mock_api_client.get_installed_unraid_plugins = AsyncMock(return_value="bad")
     assert await coordinator._query_installed_plugins() == []
 
-    mock_api_client.query = AsyncMock(return_value=12345)
+    mock_api_client.get_installed_unraid_plugins = AsyncMock(return_value=12345)
     assert await coordinator._query_installed_plugins() == []
 
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -818,3 +818,20 @@ async def test_setup_entry_first_refresh_failure_closes_client(
             await async_setup_entry(hass, mock_config_entry)
 
     mock_unraid_client.close.assert_called_once()
+
+
+def test_is_monitorable_interface() -> None:
+    """Test is_monitorable_interface filter helper."""
+    from custom_components.unraid.const import is_monitorable_interface
+
+    assert is_monitorable_interface(None) is False
+    assert is_monitorable_interface("") is False
+    assert is_monitorable_interface("eth0") is True
+    assert is_monitorable_interface("eth1.5") is True
+    assert is_monitorable_interface("bond0") is True
+    assert is_monitorable_interface("br0") is True
+    assert is_monitorable_interface("wlan0") is True
+    assert is_monitorable_interface("docker0") is False
+    assert is_monitorable_interface("virbr0") is False
+    assert is_monitorable_interface("lo") is False
+    assert is_monitorable_interface("veth1234abc") is False

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -38,7 +38,7 @@ from unraid_api.models import (
     TemperatureSensor as TemperatureSensorModel,
 )
 
-from custom_components.unraid.const import DOMAIN
+from custom_components.unraid.const import DOMAIN, is_monitorable_interface
 from custom_components.unraid.coordinator import (
     UnraidInfraCoordinator,
     UnraidStorageCoordinator,
@@ -103,7 +103,6 @@ from custom_components.unraid.sensor import (
     UptimeSensor,
     _compute_disk_usage_percent,
     _compute_disk_used_bytes,
-    _is_monitorable_interface,
     _is_valid_system_temp_sensor,
     format_bytes,
 )
@@ -6782,7 +6781,7 @@ def test_network_interface_sensor_no_data() -> None:
 )
 def test_is_monitorable_interface(name: str | None, expected: bool) -> None:
     """Only physical NICs, bonds, and user bridges are monitorable."""
-    assert _is_monitorable_interface(name) is expected
+    assert is_monitorable_interface(name) is expected
 
 
 # =============================================================================

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -15,6 +15,9 @@ from unraid_api.models import (
     ArrayDisk,
     CapacityKilobytes,
     DockerContainer,
+    InfoNetworkInterface,
+    InfoNetworkIpv4Address,
+    InfoNetworkIpv6Address,
     NotificationOverview,
     NotificationOverviewCounts,
     ParityCheck,
@@ -60,7 +63,9 @@ from custom_components.unraid.sensor import (
     InstalledPluginsSensor,
     LastParityCheckDateSensor,
     LastParityCheckErrorsSensor,
+    NetworkInterfaceIpSensor,
     NetworkInterfaceRxSensor,
+    NetworkInterfaceSpeedSensor,
     NetworkInterfaceTxSensor,
     NotificationArchivedTotalSensor,
     NotificationUnreadAlertSensor,
@@ -7353,3 +7358,128 @@ def test_is_valid_system_temp_sensor_filters() -> None:
     assert _is_valid_system_temp_sensor(_make_temp_sensor(name="AUXTIN3")) is False
     assert _is_valid_system_temp_sensor(_make_temp_sensor(temperature=0.5)) is False
     assert _is_valid_system_temp_sensor(_make_temp_sensor(temperature=180.0)) is False
+
+
+# =============================================================================
+# NetworkInterfaceSpeedSensor & NetworkInterfaceIpSensor Tests
+# =============================================================================
+
+
+def test_network_interface_speed_sensor_properties_and_state() -> None:
+    """Test NetworkInterfaceSpeedSensor properties, native_value, and attributes."""
+    iface = InfoNetworkInterface(
+        id="eth0",
+        name="eth0",
+        speed=1000,
+        duplex="full",
+        operstate="up",
+    )
+    coordinator = MagicMock(spec=UnraidSystemCoordinator)
+    coordinator.data = make_system_data(network_interfaces=[iface])
+    coordinator.last_update_success = True
+
+    sensor = NetworkInterfaceSpeedSensor(
+        coordinator=coordinator,
+        server_uuid="uuid-1",
+        server_name="tower",
+        interface_name="eth0",
+    )
+
+    assert sensor.translation_key == "network_interface_speed"
+    assert sensor.translation_placeholders == {"name": "eth0"}
+    assert sensor.unique_id == "uuid-1_network_eth0_speed"
+    assert sensor.device_class == SensorDeviceClass.DATA_RATE
+    assert sensor.native_value == 1000
+    assert sensor.extra_state_attributes == {"duplex": "full", "operstate": "up"}
+
+
+def test_network_interface_speed_sensor_missing_or_none() -> None:
+    """Test NetworkInterfaceSpeedSensor when interface is missing or data is None."""
+    iface = InfoNetworkInterface(id="eth0", name="eth0", speed=None)
+    coordinator = MagicMock(spec=UnraidSystemCoordinator)
+    coordinator.data = make_system_data(network_interfaces=[iface])
+
+    sensor = NetworkInterfaceSpeedSensor(
+        coordinator=coordinator,
+        server_uuid="uuid-1",
+        server_name="tower",
+        interface_name="eth0",
+    )
+    assert sensor.native_value is None
+
+    # When interface missing from coordinator data
+    coordinator.data = make_system_data(network_interfaces=[])
+    assert sensor.native_value is None
+    assert sensor.extra_state_attributes == {}
+
+    # When coordinator data is None
+    coordinator.data = None
+    assert sensor.native_value is None
+    assert sensor.extra_state_attributes == {}
+
+
+def test_network_interface_ip_sensor_properties_and_state() -> None:
+    """Test NetworkInterfaceIpSensor properties, native_value, and attributes."""
+    iface = InfoNetworkInterface(
+        id="br0",
+        name="br0",
+        ipAddress="192.168.20.21",
+        macAddress="00:11:22:33:44:55",
+        netmask="255.255.255.0",
+        gateway="192.168.20.1",
+        ipv4Addresses=[
+            InfoNetworkIpv4Address(address="192.168.20.21", netmask="255.255.255.0")
+        ],
+        ipv6Address="fe80::1",
+        ipv6Addresses=[InfoNetworkIpv6Address(address="fe80::1", prefixLength=64)],
+    )
+    coordinator = MagicMock(spec=UnraidSystemCoordinator)
+    coordinator.data = make_system_data(network_interfaces=[iface])
+    coordinator.last_update_success = True
+
+    sensor = NetworkInterfaceIpSensor(
+        coordinator=coordinator,
+        server_uuid="uuid-1",
+        server_name="tower",
+        interface_name="br0",
+    )
+
+    assert sensor.translation_key == "network_interface_ip"
+    assert sensor.translation_placeholders == {"name": "br0"}
+    assert sensor.unique_id == "uuid-1_network_br0_ip"
+    assert sensor.native_value == "192.168.20.21"
+
+    attrs = sensor.extra_state_attributes
+    assert attrs["mac_address"] == "00:11:22:33:44:55"
+    assert attrs["netmask"] == "255.255.255.0"
+    assert attrs["gateway"] == "192.168.20.1"
+    assert attrs["ipv4_addresses"] == [
+        {"address": "192.168.20.21", "netmask": "255.255.255.0"}
+    ]
+    assert attrs["ipv6_address"] == "fe80::1"
+    assert attrs["ipv6_addresses"] == [{"address": "fe80::1", "prefix_length": 64}]
+
+
+def test_network_interface_ip_sensor_missing_or_none() -> None:
+    """Test NetworkInterfaceIpSensor when interface is missing or ipAddress is None."""
+    iface = InfoNetworkInterface(id="br0", name="br0", ipAddress=None)
+    coordinator = MagicMock(spec=UnraidSystemCoordinator)
+    coordinator.data = make_system_data(network_interfaces=[iface])
+
+    sensor = NetworkInterfaceIpSensor(
+        coordinator=coordinator,
+        server_uuid="uuid-1",
+        server_name="tower",
+        interface_name="br0",
+    )
+    assert sensor.native_value is None
+
+    # When interface missing from coordinator data
+    coordinator.data = make_system_data(network_interfaces=[])
+    assert sensor.native_value is None
+    assert sensor.extra_state_attributes == {}
+
+    # When coordinator data is None
+    coordinator.data = None
+    assert sensor.native_value is None
+    assert sensor.extra_state_attributes == {}

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -17,6 +17,7 @@ from custom_components.unraid.coordinator import (
 from custom_components.unraid.switch import (
     ArraySwitch,
     DiskSpinSwitch,
+    DockerContainerAutostartSwitch,
     DockerContainerSwitch,
     ParityCheckSwitch,
     VirtualMachineSwitch,
@@ -1566,9 +1567,11 @@ async def test_setup_creates_container_switches(hass) -> None:
 
     await async_setup_entry(hass, mock_entry, mock_add_entities)
 
-    # Should have: ArraySwitch, ParityCheckSwitch, DockerContainerSwitch
-    assert len(added_entities) == 3
+    # Should have: ArraySwitch, ParityCheckSwitch, DockerContainerSwitch,
+    # and DockerContainerAutostartSwitch
+    assert len(added_entities) == 4
     assert any(isinstance(e, DockerContainerSwitch) for e in added_entities)
+    assert any(isinstance(e, DockerContainerAutostartSwitch) for e in added_entities)
 
 
 @pytest.mark.asyncio
@@ -1813,3 +1816,112 @@ def test_diskspinswitch_returns_none_when_disk_missing() -> None:
 
     assert switch.is_on is None
     assert switch.extra_state_attributes == {}
+
+
+# =============================================================================
+# DockerContainerAutostartSwitch Tests
+# =============================================================================
+
+
+def test_container_autostart_switch_properties() -> None:
+    """Test DockerContainerAutostartSwitch properties and state."""
+    container = DockerContainer(id="c1", name="/plex", state="RUNNING", autoStart=True)
+    coordinator = MagicMock(spec=UnraidSystemCoordinator)
+    coordinator.data = make_system_data(containers=[container])
+    coordinator.last_update_success = True
+
+    switch = DockerContainerAutostartSwitch(
+        coordinator=coordinator,
+        server_uuid="uuid-1",
+        server_name="tower",
+        container=container,
+    )
+
+    assert switch.translation_key == "docker_container_autostart"
+    assert switch.translation_placeholders == {"name": "plex"}
+    assert switch.unique_id == "uuid-1_container_autostart_plex"
+    assert switch.is_on is True
+    assert switch.available is True
+
+
+def test_container_autostart_switch_off_state() -> None:
+    """Test DockerContainerAutostartSwitch is_on when autostart is False or None."""
+    container = DockerContainer(id="c1", name="/plex", state="RUNNING", autoStart=False)
+    coordinator = MagicMock(spec=UnraidSystemCoordinator)
+    coordinator.data = make_system_data(containers=[container])
+
+    switch = DockerContainerAutostartSwitch(
+        coordinator=coordinator,
+        server_uuid="uuid-1",
+        server_name="tower",
+        container=container,
+    )
+    assert switch.is_on is False
+
+    container_none = DockerContainer(
+        id="c2", name="/none", state="RUNNING", autoStart=None
+    )
+    coordinator.data = make_system_data(containers=[container_none])
+    switch_none = DockerContainerAutostartSwitch(
+        coordinator=coordinator,
+        server_uuid="uuid-1",
+        server_name="tower",
+        container=container_none,
+    )
+    assert switch_none.is_on is False
+
+
+@pytest.mark.asyncio
+async def test_container_autostart_switch_turn_on_and_off() -> None:
+    """Test turn_on and turn_off operations for DockerContainerAutostartSwitch."""
+    container = DockerContainer(id="c1", name="/plex", state="RUNNING", autoStart=False)
+    coordinator = MagicMock(spec=UnraidSystemCoordinator)
+    coordinator.data = make_system_data(containers=[container])
+    coordinator.async_update_container_autostart = AsyncMock()
+
+    switch = DockerContainerAutostartSwitch(
+        coordinator=coordinator,
+        server_uuid="uuid-1",
+        server_name="tower",
+        container=container,
+    )
+
+    await switch.async_turn_on()
+    coordinator.async_update_container_autostart.assert_called_once_with(
+        "c1", auto_start=True
+    )
+
+    coordinator.async_update_container_autostart.reset_mock()
+    await switch.async_turn_off()
+    coordinator.async_update_container_autostart.assert_called_once_with(
+        "c1", auto_start=False
+    )
+
+
+@pytest.mark.asyncio
+async def test_container_autostart_switch_error_handling() -> None:
+    """Test error handling in DockerContainerAutostartSwitch."""
+    container = DockerContainer(id="c1", name="/plex", state="RUNNING", autoStart=False)
+    coordinator = MagicMock(spec=UnraidSystemCoordinator)
+    coordinator.data = make_system_data(containers=[container])
+    coordinator.async_update_container_autostart = AsyncMock(
+        side_effect=UnraidAPIError("Mutation failed")
+    )
+
+    switch = DockerContainerAutostartSwitch(
+        coordinator=coordinator,
+        server_uuid="uuid-1",
+        server_name="tower",
+        container=container,
+    )
+
+    with pytest.raises(HomeAssistantError):
+        await switch.async_turn_on()
+
+    # When container is missing
+    coordinator.data = make_system_data(containers=[])
+    coordinator.async_update_container_autostart = AsyncMock()
+    with pytest.raises(HomeAssistantError) as exc_info:
+        await switch.async_turn_on()
+    assert exc_info.value.translation_key == "container_not_found"
+    coordinator.async_update_container_autostart.assert_not_called()

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -1840,6 +1840,7 @@ def test_container_autostart_switch_properties() -> None:
     assert switch.translation_key == "docker_container_autostart"
     assert switch.translation_placeholders == {"name": "plex"}
     assert switch.unique_id == "uuid-1_container_autostart_plex"
+    assert switch.entity_registry_enabled_default is False
     assert switch.is_on is True
     assert switch.available is True
 

--- a/uv.lock
+++ b/uv.lock
@@ -1268,7 +1268,7 @@ requires-dist = [
     { name = "pytest-timeout", marker = "extra == 'test'", specifier = ">=2.4.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = "==0.16.5" },
     { name = "syrupy", marker = "extra == 'test'", specifier = ">=5.5.3" },
-    { name = "unraid-api", specifier = ">=1.12.1" },
+    { name = "unraid-api", specifier = ">=1.13.1" },
 ]
 provides-extras = ["test", "dev"]
 
@@ -3148,16 +3148,16 @@ wheels = [
 
 [[package]]
 name = "unraid-api"
-version = "1.12.1"
+version = "1.13.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
     { name = "packaging" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/68/61/52ea4ad61d0b032362a985154a179fa6ba8a2ffcce453576075b37ca1b78/unraid_api-1.12.1.tar.gz", hash = "sha256:44a7ce5f9fee4e459b35e97f41b2983dd6a58d27c94054302fbf5c1a7bd03c24", size = 52794, upload-time = "2026-06-26T02:21:59.9Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a9/c8/6a4743f5b19fc9a4358990686ab6094bddb52f0792f72469575eff52c0e6/unraid_api-1.13.1.tar.gz", hash = "sha256:418193a571f2dd44c5200dd220d13aa1048b2f933e0b8b6e2f41e9088f08c13e", size = 58464, upload-time = "2026-09-03T23:16:46.883Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/da/56/2804d8fa0dfc3f765cd91da1358aa4e305640b30be6cc4784b80683a122c/unraid_api-1.12.1-py3-none-any.whl", hash = "sha256:3cded0f7bf1730d9ee51ece3fafe13f899541996315a3eaa35a5b420f78b3ed3", size = 54469, upload-time = "2026-06-26T02:21:58.543Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/67/97ad36b3b0d2337747af712a3de3f41e04df291dee1d3e67ffef362937ee/unraid_api-1.13.1-py3-none-any.whl", hash = "sha256:5e604e28edc6c683f74d5ad7907b191e024161aefc29c6ce76fd638baacecd10", size = 60136, upload-time = "2026-09-03T23:16:45.472Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

Upgrades `unraid-api` to v1.13.1, eliminates the direct GraphQL query in `UnraidInfraCoordinator`, and implements 6 new entity types to expose the new features provided by `unraid-api` v1.13.1.

### 1. Upgrade `unraid-api` to 1.13.1 & Enforce API Boundary
- Bumped `unraid-api` requirement to `>=1.13.1` in `manifest.json` and `pyproject.toml`.
- Resolves upstream schema input type for container autostart mutations (`DockerAutostartEntryInput`).
- Replaced the direct GraphQL query in `coordinator.py` (`query { installedUnraidPlugins }`) with `api_client.get_installed_unraid_plugins()`, strictly complying with the critical rule: *Never bypass `unraid-api`*.

### 2. New Entities Implemented
- **Docker Container Autostart Switch** (`switch.{server}_container_{name}_autostart`): Config category switch dynamically generated per container that controls `update_container_autostart(container_id, auto_start=...)`.
- **Network Interface Link Binary Sensor** (`binary_sensor.{server}_network_{iface}_link`): `connectivity` device class monitoring link state (`operstate == 'up'`) with extended attributes (MAC, IP, MTU, duplex, speed).
- **Network Interface Speed Sensor** (`sensor.{server}_network_{iface}_speed`): Measurement sensor in `Mbit/s` (`DATA_RATE` class) to detect Ethernet link degradation.
- **Network Interface IP Address Sensor** (`sensor.{server}_network_{iface}_ip`): Diagnostic sensor reporting primary IPv4 address, IPv6, netmask, and gateway.
- **Plugin Installation Binary Sensor** (`binary_sensor.{server}_plugin_installing`): `running` device class sensor updated every 30 seconds via `system_coordinator` to reflect active plugin installations.
- **Recalculate Notifications Button** (`button.{server}_recalculate_notifications`): Diagnostic button to trigger `recalculate_notification_overview()`.
- **Clear Disk Statistics Button** (`button.{server}_disk_{id}_clear_statistics`): Config button (disabled by default) dynamically registered for all array/pool disks to reset disk read/write/error statistics.

### 3. Dynamic Registration & Cleanup
- Added dynamic entity registration and cleanup handling in `cleanup.py` for container autostart switches, network interface entities, and disk statistics buttons.
- Categorized `_NETWORK_METRICS_RESOURCE_ID_RE` (`rx|tx`) under `"network_metrics"` and `_NETWORK_INTERFACE_RESOURCE_ID_RE` (`link|speed|ip`) under `"network_interfaces"`.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality / Refactoring
- [x] Documentation / Repository tooling

## ⚠️ unraid-api Boundary Verification
- [x] **No direct network I/O added**
- [x] **All data flows through `unraid-api` (`UnraidClient`)**
- [x] **Ran `./script/check`**

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have updated documentation where necessary
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fixes are effective
- [x] All 1,101 tests pass with >=95% coverage (`./script/test`)
- [x] Integration runs and passes validation (`./script/check`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Docker container autostart switches.
  * Added network interface link, speed and IP monitoring.
  * Added plugin installation status monitoring.
  * Added buttons to recalculate notifications and clear disk statistics.
  * Added translated messages for new controls and errors.

* **Documentation**
  * Updated the minimum required `unraid-api` version to 1.13.1.

* **Bug Fixes**
  * Improved refresh and availability handling for dynamic entities and network data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->