### PR TITLE
fix(deps): bump pip to >=26.2.0 to resolve CVE-2026-13346 (#73)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,7 +143,7 @@ environments = ["python_full_version >= '3.14.2'"]
 # - cryptography GHSA-m959-cc7f-wv43 (incomplete DNS name constraint)
 # - cryptography GHSA-p423-j2cm-9vmq (buffer overflow non-contiguous buffers)
 # - cryptography GHSA-537c-gmf6-5ccf (vulnerable OpenSSL in wheels)
-# - pip PYSEC-2026-196
+# - pip PYSEC-2026-196 / CVE-2026-13346 / GHSA-qwm4-qh6w-59xr (doubly-encoded package URLs)
 # - uv GHSA-pjjw-68hj-v9mw (arbitrary file deletion through RECORD entries)
 # - Pygments CVE-2026-4539 / GHSA-5239-wwwm-4pmq (ReDoS in GUID regex)
 #
@@ -156,9 +156,9 @@ environments = ["python_full_version >= '3.14.2'"]
 override-dependencies = [
     "aiohttp>=3.14.1",
     "pyjwt>=2.13.0",
-    "pyopenssl>=26.0.0",
+    "pyopenssl>=26.4.0",
     "cryptography>=48.0.1",
-    "pip>=26.1.2",
+    "pip>=26.2.0",
     "uv>=0.11.6",
     "pygments>=2.20.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,7 +143,7 @@ environments = ["python_full_version >= '3.14.2'"]
 # - cryptography GHSA-m959-cc7f-wv43 (incomplete DNS name constraint)
 # - cryptography GHSA-p423-j2cm-9vmq (buffer overflow non-contiguous buffers)
 # - cryptography GHSA-537c-gmf6-5ccf (vulnerable OpenSSL in wheels)
-# - pip PYSEC-2026-196 / CVE-2026-13346 / GHSA-qwm4-qh6w-59xr (doubly-encoded package URLs)
+# - pip PYSEC-2026-3721 / CVE-2026-13346 / GHSA-qwm4-qh6w-59xr (doubly-encoded package URLs)
 # - uv GHSA-pjjw-68hj-v9mw (arbitrary file deletion through RECORD entries)
 # - Pygments CVE-2026-4539 / GHSA-5239-wwwm-4pmq (ReDoS in GUID regex)
 #

--- a/uv.lock
+++ b/uv.lock
@@ -13,10 +13,10 @@ supported-markers = [
 overrides = [
     { name = "aiohttp", specifier = ">=3.14.1" },
     { name = "cryptography", specifier = ">=48.0.1" },
-    { name = "pip", specifier = ">=26.1.2" },
+    { name = "pip", specifier = ">=26.2.0" },
     { name = "pygments", specifier = ">=2.20.0" },
     { name = "pyjwt", specifier = ">=2.13.0" },
-    { name = "pyopenssl", specifier = ">=26.0.0" },
+    { name = "pyopenssl", specifier = ">=26.4.0" },
     { name = "uv", specifier = ">=0.11.6" },
 ]
 
@@ -2047,11 +2047,11 @@ wheels = [
 
 [[package]]
 name = "pip"
-version = "26.1.2"
+version = "26.2.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/01/91/47e7d486260f618783899587af63ccf7980fb60245c3e63dd4571c6b57ad/pip-26.1.2.tar.gz", hash = "sha256:f49cd134c61cf2fd75e0ce2676db03e4054504a5a4986d00f8299ae632dc4605", size = 1840799, upload-time = "2026-05-31T17:33:58.56Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ae/15/4500e320e6b101ec3b719ae85b697d9940b6cda672bc555bd6016fc60c6f/pip-26.2.1.tar.gz", hash = "sha256:f6ad667e89a1fe78046c8f13232b247200f5258d7828f3f7883d660878e0813f", size = 1848877, upload-time = "2026-08-04T22:51:14.148Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/95/6b5cb3461ea5673ba0995989746db58eb18b91b54dbf331e72f569540946/pip-26.1.2-py3-none-any.whl", hash = "sha256:382ff9f685ee3bc25864f820aa50505825f10f5458ffff07e30a6d96e5715cab", size = 1813144, upload-time = "2026-05-31T17:33:56.772Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/6e/1736e5b4ae2b778ef2f81c47d797de9f891d4d8acb047a24ca37a60294dd/pip-26.2.1-py3-none-any.whl", hash = "sha256:71138adf1f4ca900cdb7d289c21b7494329f2332b6d85f0e1c42108c0384ed3e", size = 1816632, upload-time = "2026-08-04T22:51:12.472Z" },
 ]
 
 [[package]]
@@ -2499,14 +2499,14 @@ wheels = [
 
 [[package]]
 name = "pyopenssl"
-version = "26.0.0"
+version = "26.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cryptography" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8e/11/a62e1d33b373da2b2c2cd9eb508147871c80f12b1cacde3c5d314922afdd/pyopenssl-26.0.0.tar.gz", hash = "sha256:f293934e52936f2e3413b89c6ce36df66a0b34ae1ea3a053b8c5020ff2f513fc", size = 185534, upload-time = "2026-03-15T14:28:26.353Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3f/e8/7325d258199b159eb2c03fe32107533e2832e70e63f4fb88a6aa00023201/pyopenssl-26.4.0.tar.gz", hash = "sha256:28dfcce0162b9211413e26dfbfdf1d24317fbeba18fc93c12400a1856b2a0bc7", size = 182046, upload-time = "2026-08-01T19:50:50.512Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fb/7d/d4f7d908fa8415571771b30669251d57c3cf313b36a856e6d7548ae01619/pyopenssl-26.0.0-py3-none-any.whl", hash = "sha256:df94d28498848b98cc1c0ffb8ef1e71e40210d3b0a8064c9d29571ed2904bf81", size = 57969, upload-time = "2026-03-15T14:28:24.864Z" },
+    { url = "https://files.pythonhosted.org/packages/51/ad/2cf6d3fa2fae5c79e1ed9960c0d42badd0f94d81dd12b50604cdc839e648/pyopenssl-26.4.0-py3-none-any.whl", hash = "sha256:f0eb0cb2d581d3ad2b9c489468485e7f2ab6727d08401bcf9d824c3caddf3c1c", size = 56026, upload-time = "2026-08-01T19:50:48.94Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

Resolves Dependabot security alert #73 (CVE-2026-13346 / GHSA-qwm4-qh6w-59xr): *pip would incorrectly handle doubly-encoded package URLs from indexes*.

### Summary of Changes
- Updated `override-dependencies` in `pyproject.toml` to specify `pip>=26.2.0` and `pyopenssl>=26.4.0`.
- `pyopenssl` was bumped to `>=26.4.0` to maintain ABI compatibility with `cryptography 50.0.0` (resolves `AttributeError: module 'lib' has no attribute 'GEN_EMAIL'`).
- Regenerated `uv.lock` with resolved packages:
  - `pip`: `26.1.2` -> `26.2.1`
  - `pyopenssl`: `26.0.0` -> `26.4.0`
- Passed pre-commit security audit (`pip-audit`), `./script/check`, and all 1,101 test cases with 96% coverage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Updated security safeguards for certificate and package management components.
  * Incorporated the latest applicable security advisory identifiers and minimum security fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->