### PR TITLE
feat: add VM status sensors and container RAM sensors (#268, #283)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Calendar Versioning](https://calver.org/) (YYYY.MM.
 
 ## [Unreleased]
 
+### Added
+
+- **VM Status Sensors** ([#268](https://github.com/ruaan-deysel/ha-unraid/issues/268)): Added dedicated sensor entities (`sensor.*_vm_status_*`) for virtual machines reporting their current state (e.g. `running`, `paused`, `shutoff`, `pmsuspended`, `crashed`, `idle`, `blocked`) along with `vm_id`, `raw_state`, and hardware configuration attributes (`memory`, `vcpu`, `auto_start`, `primary_gpu`).
+- **Docker Container Memory Used and Limit Sensors** ([#283](https://github.com/ruaan-deysel/ha-unraid/issues/283)): Added numeric memory sensors (`sensor.*_container_*_memory_used` and `sensor.*_container_*_memory_limit`, disabled by default) for Docker containers reporting exact memory usage and limit in bytes (with suggested unit MB) parsed from container WebSocket statistics, enabling numeric threshold automations (such as restarting leaking containers).
+
 ## [2026.9.1] - 2026-09-04
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Calendar Versioning](https://calver.org/) (YYYY.MM.
 
 ### Added
 
-- **VM Status Sensors** ([#268](https://github.com/ruaan-deysel/ha-unraid/issues/268)): Added dedicated sensor entities (`sensor.*_vm_status_*`) for virtual machines reporting their current state (e.g. `running`, `paused`, `shutoff`, `pmsuspended`, `crashed`, `idle`, `blocked`) along with `vm_id`, `raw_state`, and hardware configuration attributes (`memory`, `vcpu`, `auto_start`, `primary_gpu`).
+- **VM Status Sensors** ([#268](https://github.com/ruaan-deysel/ha-unraid/issues/268)): Added dedicated sensor entities (`sensor.*_vm_status_*`) for virtual machines reporting their current state (e.g. `running`, `paused`, `shutoff`, `pmsuspended`, `crashed`, `idle`, `blocked`) along with `vm_id` and `raw_state` attributes.
 - **Docker Container Memory Used and Limit Sensors** ([#283](https://github.com/ruaan-deysel/ha-unraid/issues/283)): Added numeric memory sensors (`sensor.*_container_*_memory_used` and `sensor.*_container_*_memory_limit`, disabled by default) for Docker containers reporting exact memory usage and limit in bytes (with suggested unit MB) parsed from container WebSocket statistics, enabling numeric threshold automations (such as restarting leaking containers).
 
 ## [2026.9.1] - 2026-09-04

--- a/custom_components/unraid/cleanup.py
+++ b/custom_components/unraid/cleanup.py
@@ -79,6 +79,7 @@ _DYNAMIC_RESOURCE_ID_PREFIXES: Final[tuple[str, ...]] = (
     "container_restart_",  # per-container restart button
     "container_update_",  # per-container update entity (update platform)
     "vm_switch_",  # per-VM switch
+    "vm_status_",  # per-VM status sensor
     "vm_force_stop_",  # per-VM force-stop button
     "vm_reboot_",  # per-VM reboot button
     "vm_pause_",  # per-VM pause button
@@ -181,6 +182,8 @@ def _build_system_dynamic_unique_ids(
                 f"{pfx}container_{name}_cpu",
                 f"{pfx}container_{name}_memory",
                 f"{pfx}container_{name}_memory_pct",
+                f"{pfx}container_{name}_memory_used",
+                f"{pfx}container_{name}_memory_limit",
                 f"{pfx}container_{name}_update",
                 f"{pfx}container_update_{name}",
             }
@@ -190,6 +193,7 @@ def _build_system_dynamic_unique_ids(
         expected.update(
             {
                 f"{pfx}vm_switch_{vm.name}",
+                f"{pfx}vm_status_{vm.name}",
                 f"{pfx}vm_force_stop_{vm.name}",
                 f"{pfx}vm_reboot_{vm.name}",
                 f"{pfx}vm_pause_{vm.name}",

--- a/custom_components/unraid/icons.json
+++ b/custom_components/unraid/icons.json
@@ -157,6 +157,12 @@
       "container_memory_percent": {
         "default": "mdi:docker"
       },
+      "container_memory_used": {
+        "default": "mdi:docker"
+      },
+      "container_memory_limit": {
+        "default": "mdi:docker"
+      },
       "docker_total_cpu": {
         "default": "mdi:docker"
       },
@@ -177,6 +183,9 @@
       },
       "ups_status": {
         "default": "mdi:battery-alert-variant-outline"
+      },
+      "virtual_machine_status": {
+        "default": "mdi:desktop-tower"
       },
       "container_updates_count": {
         "default": "mdi:package-up"

--- a/custom_components/unraid/sensor.py
+++ b/custom_components/unraid/sensor.py
@@ -3639,15 +3639,6 @@ class VirtualMachineStatusSensor(UnraidSensorEntity[UnraidSystemCoordinator]):
         }
         if vm.state:
             attrs["raw_state"] = vm.state
-        for attr, key in (
-            ("memory", "memory"),
-            ("vcpu", "vcpu"),
-            ("autostart", "auto_start"),
-            ("primaryGpu", "primary_gpu"),
-        ):
-            value = getattr(vm, attr, None)
-            if value is not None:
-                attrs[key] = value
         return attrs
 
 

--- a/custom_components/unraid/sensor.py
+++ b/custom_components/unraid/sensor.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 import logging
+import re
 from datetime import UTC, datetime
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Final
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -15,6 +16,7 @@ from homeassistant.const import (
     EntityCategory,
     UnitOfDataRate,
     UnitOfEnergy,
+    UnitOfInformation,
     UnitOfPower,
     UnitOfTemperature,
 )
@@ -52,6 +54,7 @@ if TYPE_CHECKING:
         ParityHistoryEntry,
         Share,
         UPSDevice,
+        VmDomain,
     )
     from unraid_api.models import (
         TemperatureSensor as TemperatureSensorModel,
@@ -2235,6 +2238,61 @@ class ShareUsageSensor(UnraidSensorEntity[UnraidStorageCoordinator]):
 # to these sensor entities.
 
 
+# Multipliers for parsing Docker memory strings to bytes
+_DOCKER_MEM_MULTIPLIERS: Final[dict[str, int]] = {
+    "b": 1,
+    "k": 1024,
+    "kb": 1000,
+    "kib": 1024,
+    "m": 1024**2,
+    "mb": 1000**2,
+    "mib": 1024**2,
+    "g": 1024**3,
+    "gb": 1000**3,
+    "gib": 1024**3,
+    "t": 1024**4,
+    "tb": 1000**4,
+    "tib": 1024**4,
+    "p": 1024**5,
+    "pb": 1000**5,
+    "pib": 1024**5,
+}
+
+_DOCKER_MEM_RE: Final = re.compile(r"^([\d.]+)\s*([a-zA-Z]+)?$")
+
+
+def _parse_size_to_bytes(size_str: str) -> int | None:
+    """Parse human-readable size string (e.g., '245.5MiB') into integer bytes."""
+    match = _DOCKER_MEM_RE.match(size_str.strip())
+    if not match:
+        return None
+    val_str, unit_str = match.groups()
+    try:
+        val = float(val_str)
+    except ValueError:
+        return None
+    if not unit_str:
+        return int(val)
+    mult = _DOCKER_MEM_MULTIPLIERS.get(unit_str.lower())
+    if mult is None:
+        return None
+    return int(val * mult)
+
+
+def parse_docker_mem_usage(mem_usage: str | None) -> tuple[int | None, int | None]:
+    """
+    Parse Docker memory usage string into (used_bytes, limit_bytes).
+
+    Example inputs:
+        '245.5MiB / 15.61GiB' -> (257425408, 16761109872)
+        '0B / 0B' -> (0, 0)
+    """
+    if not mem_usage or "/" not in mem_usage:
+        return (None, None)
+    parts = mem_usage.split("/", 1)
+    return (_parse_size_to_bytes(parts[0]), _parse_size_to_bytes(parts[1]))
+
+
 class _ContainerStatsMixin:
     """
     Shared lookup logic for per-container WebSocket stat sensors.
@@ -2431,6 +2489,104 @@ class ContainerMemoryPercentSensor(
         if stats is None or stats.memPercent is None:
             return None
         return round(stats.memPercent, 1)
+
+
+class ContainerMemoryUsedSensor(
+    _ContainerStatsMixin, UnraidBaseEntity[UnraidSystemCoordinator], SensorEntity
+):
+    """Container memory used in bytes (WebSocket-powered)."""
+
+    _attr_translation_key = "container_memory_used"
+    _attr_device_class = SensorDeviceClass.DATA_SIZE
+    _attr_native_unit_of_measurement = UnitOfInformation.BYTES
+    _attr_suggested_unit_of_measurement = UnitOfInformation.MEGABYTES
+    _attr_suggested_display_precision = 1
+    _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_entity_registry_enabled_default = False
+
+    def __init__(
+        self,
+        coordinator: UnraidSystemCoordinator,
+        server_uuid: str,
+        server_name: str,
+        container_name: str,
+        container_id: str,
+        ws_manager: UnraidWebSocketManager,
+    ) -> None:
+        """Initialize container memory used sensor."""
+        self._container_name = container_name
+        self._container_id = container_id
+        self._ws_manager = ws_manager
+        super().__init__(
+            coordinator=coordinator,
+            server_uuid=server_uuid,
+            server_name=server_name,
+            resource_id=f"container_{container_name}_memory_used",
+            name=f"Container {container_name} Memory Used",
+        )
+        self._attr_translation_placeholders = {
+            "name": container_name,
+        }
+
+    @property
+    def native_value(self) -> int | None:
+        """Return container memory used in bytes (0 when stopped)."""
+        if self._is_container_stopped():
+            return 0
+        stats = self._get_current_stats()
+        if stats is None or not stats.memUsage:
+            return None
+        used, _ = parse_docker_mem_usage(stats.memUsage)
+        return used
+
+
+class ContainerMemoryLimitSensor(
+    _ContainerStatsMixin, UnraidBaseEntity[UnraidSystemCoordinator], SensorEntity
+):
+    """Container memory limit in bytes (WebSocket-powered)."""
+
+    _attr_translation_key = "container_memory_limit"
+    _attr_device_class = SensorDeviceClass.DATA_SIZE
+    _attr_native_unit_of_measurement = UnitOfInformation.BYTES
+    _attr_suggested_unit_of_measurement = UnitOfInformation.MEGABYTES
+    _attr_suggested_display_precision = 1
+    _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_entity_registry_enabled_default = False
+
+    def __init__(
+        self,
+        coordinator: UnraidSystemCoordinator,
+        server_uuid: str,
+        server_name: str,
+        container_name: str,
+        container_id: str,
+        ws_manager: UnraidWebSocketManager,
+    ) -> None:
+        """Initialize container memory limit sensor."""
+        self._container_name = container_name
+        self._container_id = container_id
+        self._ws_manager = ws_manager
+        super().__init__(
+            coordinator=coordinator,
+            server_uuid=server_uuid,
+            server_name=server_name,
+            resource_id=f"container_{container_name}_memory_limit",
+            name=f"Container {container_name} Memory Limit",
+        )
+        self._attr_translation_placeholders = {
+            "name": container_name,
+        }
+
+    @property
+    def native_value(self) -> int | None:
+        """Return container memory limit in bytes (0 when stopped)."""
+        if self._is_container_stopped():
+            return 0
+        stats = self._get_current_stats()
+        if stats is None or not stats.memUsage:
+            return None
+        _, limit = parse_docker_mem_usage(stats.memUsage)
+        return limit
 
 
 # =============================================================================
@@ -3408,6 +3564,93 @@ def _get_valid_temperature_sensors(
     ]
 
 
+# =============================================================================
+# Virtual Machine Sensors
+# =============================================================================
+
+
+class VirtualMachineStatusSensor(UnraidSensorEntity[UnraidSystemCoordinator]):
+    """Sensor tracking virtual machine state."""
+
+    _attr_translation_key = "virtual_machine_status"
+
+    def __init__(
+        self,
+        coordinator: UnraidSystemCoordinator,
+        server_uuid: str,
+        server_name: str,
+        vm: VmDomain,
+        server_info: dict | None = None,
+    ) -> None:
+        """Initialize virtual machine status sensor."""
+        self._vm_name = vm.name
+        self._vm_id = vm.id
+        self._cached_vm: VmDomain | None = None
+        self._cache_data: UnraidSystemData | None = None
+        super().__init__(
+            coordinator=coordinator,
+            server_uuid=server_uuid,
+            server_name=server_name,
+            resource_id=f"vm_status_{self._vm_name}",
+            name=f"VM {vm.name} Status",
+            server_info=server_info,
+        )
+        self._attr_translation_placeholders = {"name": self._vm_name}
+
+    def _get_vm(self) -> VmDomain | None:
+        """Get current VM from coordinator data with caching."""
+        data: UnraidSystemData | None = self.coordinator.data
+        if data is None:
+            return None
+
+        if data is self._cache_data and self._cached_vm is not None:
+            return self._cached_vm
+
+        vm_map = {v.name: v for v in data.vms}
+        self._cached_vm = vm_map.get(self._vm_name)
+        self._cache_data = data
+
+        if self._cached_vm is not None:
+            self._vm_id = self._cached_vm.id
+
+        return self._cached_vm
+
+    @property
+    def available(self) -> bool:
+        """Return True if coordinator updated successfully and VM exists."""
+        return super().available and self._get_vm() is not None
+
+    @property
+    def native_value(self) -> str | None:
+        """Return VM state."""
+        vm = self._get_vm()
+        if vm is None or vm.state is None:
+            return None
+        return vm.state.lower()
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return extra state attributes."""
+        vm = self._get_vm()
+        if vm is None:
+            return {}
+        attrs: dict[str, Any] = {
+            "vm_id": self._vm_id,
+        }
+        if vm.state:
+            attrs["raw_state"] = vm.state
+        for attr, key in (
+            ("memory", "memory"),
+            ("vcpu", "vcpu"),
+            ("autostart", "auto_start"),
+            ("primaryGpu", "primary_gpu"),
+        ):
+            value = getattr(vm, attr, None)
+            if value is not None:
+                attrs[key] = value
+        return attrs
+
+
 async def async_setup_entry(
     hass: HomeAssistant,
     entry: UnraidConfigEntry,
@@ -3561,6 +3804,44 @@ async def async_setup_entry(
                     container.name.lstrip("/"),
                     container.id or container.name.lstrip("/"),
                     ws_manager,
+                ),
+                ContainerMemoryUsedSensor(
+                    system_coordinator,
+                    server_uuid,
+                    server_name,
+                    container.name.lstrip("/"),
+                    container.id or container.name.lstrip("/"),
+                    ws_manager,
+                ),
+                ContainerMemoryLimitSensor(
+                    system_coordinator,
+                    server_uuid,
+                    server_name,
+                    container.name.lstrip("/"),
+                    container.id or container.name.lstrip("/"),
+                    ws_manager,
+                ),
+            ],
+        )
+    )
+
+    # Virtual machine status sensors. VMs created after setup get sensors on
+    # the next coordinator refresh — no reload needed.
+    entry.async_on_unload(
+        async_add_dynamic_resource_entities(
+            coordinator=system_coordinator,
+            async_add_entities=async_add_entities,
+            get_resources=lambda: (
+                system_coordinator.data.vms if system_coordinator.data else []
+            ),
+            get_key=lambda vm: vm.name,
+            create_entities=lambda vm: [
+                VirtualMachineStatusSensor(
+                    system_coordinator,
+                    server_uuid,
+                    server_name,
+                    vm,
+                    server_info,
                 ),
             ],
         )

--- a/custom_components/unraid/strings.json
+++ b/custom_components/unraid/strings.json
@@ -336,6 +336,12 @@
       "container_memory_percent": {
         "name": "Container {name} memory %"
       },
+      "container_memory_used": {
+        "name": "Container {name} memory used"
+      },
+      "container_memory_limit": {
+        "name": "Container {name} memory limit"
+      },
       "docker_total_cpu": {
         "name": "Docker total CPU"
       },
@@ -356,6 +362,9 @@
       },
       "ups_status": {
         "name": "UPS {name} status"
+      },
+      "virtual_machine_status": {
+        "name": "VM {name} status"
       },
       "container_updates_count": {
         "name": "Container updates available"

--- a/custom_components/unraid/translations/en.json
+++ b/custom_components/unraid/translations/en.json
@@ -336,6 +336,12 @@
       "container_memory_percent": {
         "name": "Container {name} memory %"
       },
+      "container_memory_used": {
+        "name": "Container {name} memory used"
+      },
+      "container_memory_limit": {
+        "name": "Container {name} memory limit"
+      },
       "docker_total_cpu": {
         "name": "Docker total CPU"
       },
@@ -356,6 +362,9 @@
       },
       "ups_status": {
         "name": "UPS {name} status"
+      },
+      "virtual_machine_status": {
+        "name": "VM {name} status"
       },
       "container_updates_count": {
         "name": "Container updates available"

--- a/tests/test_cleanup.py
+++ b/tests/test_cleanup.py
@@ -55,9 +55,11 @@ class TestIsDynamicResourceId:
         assert _is_dynamic_resource_id("container_myapp_memory_pct") is True
 
     def test_container_memory_used_sensor(self) -> None:
+        """Dynamic container memory used resource ID is recognized."""
         assert _is_dynamic_resource_id("container_myapp_memory_used") is True
 
     def test_container_memory_limit_sensor(self) -> None:
+        """Dynamic container memory limit resource ID is recognized."""
         assert _is_dynamic_resource_id("container_myapp_memory_limit") is True
 
     def test_container_update_sensor(self) -> None:
@@ -67,6 +69,7 @@ class TestIsDynamicResourceId:
         assert _is_dynamic_resource_id("vm_switch_myvm") is True
 
     def test_vm_status(self) -> None:
+        """Dynamic VM status resource ID is recognized."""
         assert _is_dynamic_resource_id("vm_status_myvm") is True
 
     def test_vm_force_stop(self) -> None:

--- a/tests/test_cleanup.py
+++ b/tests/test_cleanup.py
@@ -54,11 +54,20 @@ class TestIsDynamicResourceId:
     def test_container_memory_pct_sensor(self) -> None:
         assert _is_dynamic_resource_id("container_myapp_memory_pct") is True
 
+    def test_container_memory_used_sensor(self) -> None:
+        assert _is_dynamic_resource_id("container_myapp_memory_used") is True
+
+    def test_container_memory_limit_sensor(self) -> None:
+        assert _is_dynamic_resource_id("container_myapp_memory_limit") is True
+
     def test_container_update_sensor(self) -> None:
         assert _is_dynamic_resource_id("container_myapp_update") is True
 
     def test_vm_switch(self) -> None:
         assert _is_dynamic_resource_id("vm_switch_myvm") is True
+
+    def test_vm_status(self) -> None:
+        assert _is_dynamic_resource_id("vm_status_myvm") is True
 
     def test_vm_force_stop(self) -> None:
         assert _is_dynamic_resource_id("vm_force_stop_myvm") is True
@@ -231,6 +240,8 @@ class TestBuildExpectedDynamicUniqueIds:
         assert f"{_UUID}_container_myapp_cpu" in result
         assert f"{_UUID}_container_myapp_memory" in result
         assert f"{_UUID}_container_myapp_memory_pct" in result
+        assert f"{_UUID}_container_myapp_memory_used" in result
+        assert f"{_UUID}_container_myapp_memory_limit" in result
         assert f"{_UUID}_container_myapp_update" in result
         # update platform entity (different pattern from binary_sensor)
         assert f"{_UUID}_container_update_myapp" in result
@@ -247,6 +258,7 @@ class TestBuildExpectedDynamicUniqueIds:
         result = build_expected_dynamic_unique_ids(_UUID, sys_data, stor_data)
 
         assert f"{_UUID}_vm_switch_windows11" in result
+        assert f"{_UUID}_vm_status_windows11" in result
         assert f"{_UUID}_vm_force_stop_windows11" in result
         assert f"{_UUID}_vm_reboot_windows11" in result
         assert f"{_UUID}_vm_pause_windows11" in result

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -7728,10 +7728,6 @@ def test_vm_status_sensor_states(raw_state: str, expected_state: str) -> None:
 def test_vm_status_sensor_attributes() -> None:
     """Test VirtualMachineStatusSensor extra state attributes."""
     vm = VmDomain(id="vm:1", name="Ubuntu", state="RUNNING")
-    object.__setattr__(vm, "memory", 4096)
-    object.__setattr__(vm, "vcpu", 4)
-    object.__setattr__(vm, "autostart", True)
-    object.__setattr__(vm, "primaryGpu", "0000:01:00.0")
 
     coordinator = MagicMock(spec=UnraidSystemCoordinator)
     coordinator.data = make_system_data(vms=[vm])
@@ -7747,10 +7743,6 @@ def test_vm_status_sensor_attributes() -> None:
     attrs = sensor.extra_state_attributes
     assert attrs["vm_id"] == "vm:1"
     assert attrs["raw_state"] == "RUNNING"
-    assert attrs["memory"] == 4096
-    assert attrs["vcpu"] == 4
-    assert attrs["auto_start"] is True
-    assert attrs["primary_gpu"] == "0000:01:00.0"
 
 
 def test_vm_status_sensor_none_state_or_missing_vm() -> None:

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -9,6 +9,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
+from homeassistant.const import UnitOfInformation
 from homeassistant.helpers.entity import EntityCategory
 from unraid_api.models import (
     ArrayCapacity,
@@ -33,6 +34,7 @@ from unraid_api.models import (
     UPSBattery,
     UPSDevice,
     UPSPower,
+    VmDomain,
 )
 from unraid_api.models import (
     TemperatureSensor as TemperatureSensorModel,
@@ -50,8 +52,10 @@ from custom_components.unraid.sensor import (
     ArrayStateSensor,
     ArrayUsageSensor,
     ContainerCpuSensor,
+    ContainerMemoryLimitSensor,
     ContainerMemoryPercentSensor,
     ContainerMemoryUsageSensor,
+    ContainerMemoryUsedSensor,
     ContainerUpdatesCountSensor,
     CpuPowerSensor,
     CpuSensor,
@@ -101,10 +105,12 @@ from custom_components.unraid.sensor import (
     UPSRuntimeSensor,
     UPSStatusSensor,
     UptimeSensor,
+    VirtualMachineStatusSensor,
     _compute_disk_usage_percent,
     _compute_disk_used_bytes,
     _is_valid_system_temp_sensor,
     format_bytes,
+    parse_docker_mem_usage,
 )
 from tests.conftest import make_infra_data, make_storage_data, make_system_data
 
@@ -7482,3 +7488,368 @@ def test_network_interface_ip_sensor_missing_or_none() -> None:
     coordinator.data = None
     assert sensor.native_value is None
     assert sensor.extra_state_attributes == {}
+
+
+# =============================================================================
+# Docker Memory String Parser Tests
+# =============================================================================
+
+
+def test_parse_docker_mem_usage_iec_units() -> None:
+    """Test parsing Docker memory strings with binary/IEC units."""
+    used, limit = parse_docker_mem_usage("245.5MiB / 15.61GiB")
+    assert used == int(245.5 * 1024 * 1024)
+    assert limit == int(15.61 * 1024 * 1024 * 1024)
+
+    used, limit = parse_docker_mem_usage("512KiB / 1TiB")
+    assert used == 512 * 1024
+    assert limit == 1024**4
+
+    used, limit = parse_docker_mem_usage("100B / 1PiB")
+    assert used == 100
+    assert limit == 1024**5
+
+
+def test_parse_docker_mem_usage_si_units() -> None:
+    """Test parsing Docker memory strings with decimal/SI units."""
+    used, limit = parse_docker_mem_usage("10kB / 100MB")
+    assert used == 10 * 1000
+    assert limit == 100 * 1000 * 1000
+
+    used, limit = parse_docker_mem_usage("1.5GB / 2TB")
+    assert used == int(1.5 * 1000**3)
+    assert limit == 2 * 1000**4
+
+    used, limit = parse_docker_mem_usage("1PB / 2PB")
+    assert used == 1000**5
+    assert limit == 2 * 1000**5
+
+
+def test_parse_docker_mem_usage_zero_and_unitless() -> None:
+    """Test parsing Docker memory strings with zero values."""
+    used, limit = parse_docker_mem_usage("0B / 0B")
+    assert used == 0
+    assert limit == 0
+
+    used, limit = parse_docker_mem_usage("0 / 0")
+    assert used == 0
+    assert limit == 0
+
+
+def test_parse_docker_mem_usage_invalid() -> None:
+    """Test parsing invalid, empty, or malformed memory strings."""
+    assert parse_docker_mem_usage(None) == (None, None)
+    assert parse_docker_mem_usage("") == (None, None)
+    assert parse_docker_mem_usage("invalid") == (None, None)
+    assert parse_docker_mem_usage("512MiB") == (None, None)
+    assert parse_docker_mem_usage("512MiB / abc") == (536870912, None)
+    assert parse_docker_mem_usage("abc / 1GiB") == (None, 1073741824)
+    assert parse_docker_mem_usage("1.2.3MiB / 1GiB") == (None, 1073741824)
+    assert parse_docker_mem_usage("512XYZ / 1GiB") == (None, 1073741824)
+
+
+# =============================================================================
+# Container Memory Used & Limit Sensor Tests
+# =============================================================================
+
+
+def test_container_memory_used_sensor_properties() -> None:
+    """Test ContainerMemoryUsedSensor metadata and properties."""
+    coordinator = _stats_coordinator([_make_docker_container("plex", "c1")])
+    ws = _make_ws_manager(
+        stats={"c1": {"id": "c1", "memUsage": "512MiB / 16GiB"}},
+    )
+    sensor = ContainerMemoryUsedSensor(
+        coordinator, "test-uuid", "tower", "plex", "c1", ws
+    )
+
+    assert sensor.unique_id == "test-uuid_container_plex_memory_used"
+    assert sensor.translation_key == "container_memory_used"
+    assert sensor.translation_placeholders == {"name": "plex"}
+    assert sensor.device_class == SensorDeviceClass.DATA_SIZE
+    assert sensor.native_unit_of_measurement == UnitOfInformation.BYTES
+    assert sensor.suggested_unit_of_measurement == UnitOfInformation.MEGABYTES
+    assert sensor.suggested_display_precision == 1
+    assert sensor.state_class == SensorStateClass.MEASUREMENT
+    assert sensor.entity_registry_enabled_default is False
+    assert sensor.native_value == 536870912
+
+
+def test_container_memory_limit_sensor_properties() -> None:
+    """Test ContainerMemoryLimitSensor metadata and properties."""
+    coordinator = _stats_coordinator([_make_docker_container("plex", "c1")])
+    ws = _make_ws_manager(
+        stats={"c1": {"id": "c1", "memUsage": "512MiB / 16GiB"}},
+    )
+    sensor = ContainerMemoryLimitSensor(
+        coordinator, "test-uuid", "tower", "plex", "c1", ws
+    )
+
+    assert sensor.unique_id == "test-uuid_container_plex_memory_limit"
+    assert sensor.translation_key == "container_memory_limit"
+    assert sensor.translation_placeholders == {"name": "plex"}
+    assert sensor.device_class == SensorDeviceClass.DATA_SIZE
+    assert sensor.native_unit_of_measurement == UnitOfInformation.BYTES
+    assert sensor.suggested_unit_of_measurement == UnitOfInformation.MEGABYTES
+    assert sensor.suggested_display_precision == 1
+    assert sensor.state_class == SensorStateClass.MEASUREMENT
+    assert sensor.entity_registry_enabled_default is False
+    assert sensor.native_value == 17179869184
+
+
+def test_container_memory_sensors_stopped_container() -> None:
+    """Stopped containers report 0 for used and limit memory."""
+    coordinator = _stats_coordinator(
+        [_make_docker_container("plex", "c1", state="EXITED")]
+    )
+    ws = _make_ws_manager(
+        stats={"c1": {"id": "c1", "memUsage": "512MiB / 16GiB"}},
+    )
+    used_sensor = ContainerMemoryUsedSensor(
+        coordinator, "test-uuid", "tower", "plex", "c1", ws
+    )
+    limit_sensor = ContainerMemoryLimitSensor(
+        coordinator, "test-uuid", "tower", "plex", "c1", ws
+    )
+
+    assert used_sensor.native_value == 0
+    assert limit_sensor.native_value == 0
+
+
+def test_container_memory_sensors_missing_stats() -> None:
+    """Missing stats yield None."""
+    coordinator = _stats_coordinator([_make_docker_container("plex", "c1")])
+    ws = _make_ws_manager(stats={})
+    used_sensor = ContainerMemoryUsedSensor(
+        coordinator, "test-uuid", "tower", "plex", "c1", ws
+    )
+    limit_sensor = ContainerMemoryLimitSensor(
+        coordinator, "test-uuid", "tower", "plex", "c1", ws
+    )
+
+    assert used_sensor.native_value is None
+    assert limit_sensor.native_value is None
+
+
+def test_container_memory_sensors_empty_mem_usage() -> None:
+    """Empty or unparsable memUsage yields None."""
+    coordinator = _stats_coordinator([_make_docker_container("plex", "c1")])
+    ws = _make_ws_manager(stats={"c1": {"id": "c1", "memUsage": ""}})
+    used_sensor = ContainerMemoryUsedSensor(
+        coordinator, "test-uuid", "tower", "plex", "c1", ws
+    )
+    limit_sensor = ContainerMemoryLimitSensor(
+        coordinator, "test-uuid", "tower", "plex", "c1", ws
+    )
+
+    assert used_sensor.native_value is None
+    assert limit_sensor.native_value is None
+
+
+def test_container_memory_sensors_dynamic_name_lookup_and_fallback() -> None:
+    """Container memory sensors resolve stats by name and fall back to frozen ID."""
+    coordinator = _stats_coordinator([_make_docker_container("plex", "recreated-id")])
+    ws = _make_ws_manager(
+        stats={"recreated-id": {"id": "recreated-id", "memUsage": "1GiB / 8GiB"}},
+    )
+    used_sensor = ContainerMemoryUsedSensor(
+        coordinator, "test-uuid", "tower", "plex", "old-id", ws
+    )
+    assert used_sensor.native_value == 1024**3
+
+    # Fall back to frozen ID when coordinator data is None
+    coordinator.data = None
+    ws_fallback = _make_ws_manager(
+        stats={"old-id": {"id": "old-id", "memUsage": "2GiB / 8GiB"}},
+    )
+    limit_sensor = ContainerMemoryLimitSensor(
+        coordinator, "test-uuid", "tower", "plex", "old-id", ws_fallback
+    )
+    assert limit_sensor.native_value == 8 * 1024**3
+
+
+# =============================================================================
+# Virtual Machine Status Sensor Tests
+# =============================================================================
+
+
+def test_vm_status_sensor_properties() -> None:
+    """Test VirtualMachineStatusSensor creation and metadata."""
+    vm = VmDomain(id="vm:1", name="Ubuntu", state="RUNNING")
+    coordinator = MagicMock(spec=UnraidSystemCoordinator)
+    coordinator.data = make_system_data(vms=[vm])
+    coordinator.last_update_success = True
+
+    sensor = VirtualMachineStatusSensor(
+        coordinator=coordinator,
+        server_uuid="test-uuid",
+        server_name="test-server",
+        vm=vm,
+        server_info={"manufacturer": "Lime Tech", "model": "Unraid"},
+    )
+
+    assert sensor.unique_id == "test-uuid_vm_status_Ubuntu"
+    assert sensor.translation_key == "virtual_machine_status"
+    assert sensor.translation_placeholders == {"name": "Ubuntu"}
+    assert sensor.entity_registry_enabled_default is True
+    assert sensor.native_value == "running"
+    assert sensor.available is True
+
+
+@pytest.mark.parametrize(
+    ("raw_state", "expected_state"),
+    [
+        ("RUNNING", "running"),
+        ("PAUSED", "paused"),
+        ("SHUTOFF", "shutoff"),
+        ("PMSUSPENDED", "pmsuspended"),
+        ("CRASHED", "crashed"),
+        ("IDLE", "idle"),
+        ("BLOCKED", "blocked"),
+    ],
+)
+def test_vm_status_sensor_states(raw_state: str, expected_state: str) -> None:
+    """Test VirtualMachineStatusSensor state translation."""
+    vm = VmDomain(id="vm:1", name="Ubuntu", state=raw_state)
+    coordinator = MagicMock(spec=UnraidSystemCoordinator)
+    coordinator.data = make_system_data(vms=[vm])
+    coordinator.last_update_success = True
+
+    sensor = VirtualMachineStatusSensor(
+        coordinator=coordinator,
+        server_uuid="test-uuid",
+        server_name="test-server",
+        vm=vm,
+    )
+
+    assert sensor.native_value == expected_state
+
+
+def test_vm_status_sensor_attributes() -> None:
+    """Test VirtualMachineStatusSensor extra state attributes."""
+    vm = VmDomain(id="vm:1", name="Ubuntu", state="RUNNING")
+    object.__setattr__(vm, "memory", 4096)
+    object.__setattr__(vm, "vcpu", 4)
+    object.__setattr__(vm, "autostart", True)
+    object.__setattr__(vm, "primaryGpu", "0000:01:00.0")
+
+    coordinator = MagicMock(spec=UnraidSystemCoordinator)
+    coordinator.data = make_system_data(vms=[vm])
+    coordinator.last_update_success = True
+
+    sensor = VirtualMachineStatusSensor(
+        coordinator=coordinator,
+        server_uuid="test-uuid",
+        server_name="test-server",
+        vm=vm,
+    )
+
+    attrs = sensor.extra_state_attributes
+    assert attrs["vm_id"] == "vm:1"
+    assert attrs["raw_state"] == "RUNNING"
+    assert attrs["memory"] == 4096
+    assert attrs["vcpu"] == 4
+    assert attrs["auto_start"] is True
+    assert attrs["primary_gpu"] == "0000:01:00.0"
+
+
+def test_vm_status_sensor_none_state_or_missing_vm() -> None:
+    """Test VirtualMachineStatusSensor when VM state is None or VM is not in data."""
+    vm = VmDomain(id="vm:1", name="Ubuntu", state=None)
+    coordinator = MagicMock(spec=UnraidSystemCoordinator)
+    coordinator.data = make_system_data(vms=[vm])
+    coordinator.last_update_success = True
+
+    sensor = VirtualMachineStatusSensor(
+        coordinator=coordinator,
+        server_uuid="test-uuid",
+        server_name="test-server",
+        vm=vm,
+    )
+
+    assert sensor.native_value is None
+    assert sensor.extra_state_attributes == {"vm_id": "vm:1"}
+
+    # VM missing from coordinator data
+    coordinator.data = make_system_data(vms=[])
+    assert sensor.native_value is None
+    assert sensor.available is False
+    assert sensor.extra_state_attributes == {}
+
+    # Coordinator data is None
+    coordinator.data = None
+    assert sensor.native_value is None
+    assert sensor.available is False
+    assert sensor.extra_state_attributes == {}
+
+
+def test_vm_status_sensor_caching_and_id_update() -> None:
+    """Test VirtualMachineStatusSensor caching behavior and VM ID update."""
+    vm1 = VmDomain(id="vm:1", name="Ubuntu", state="RUNNING")
+    coordinator = MagicMock(spec=UnraidSystemCoordinator)
+    coordinator.data = make_system_data(vms=[vm1])
+    coordinator.last_update_success = True
+
+    sensor = VirtualMachineStatusSensor(
+        coordinator=coordinator,
+        server_uuid="test-uuid",
+        server_name="test-server",
+        vm=vm1,
+    )
+
+    # First access caches VM
+    assert sensor._get_vm() is vm1
+    # Repeated access with identical data returns cached instance without rebuilding map
+    assert sensor._get_vm() is vm1
+
+    # New coordinator data with updated VM ID
+    vm2 = VmDomain(id="vm:2", name="Ubuntu", state="PAUSED")
+    coordinator.data = make_system_data(vms=[vm2])
+    assert sensor._get_vm() is vm2
+    assert sensor._vm_id == "vm:2"
+    assert sensor.native_value == "paused"
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_registers_vm_and_container_ram_sensors(
+    hass,
+) -> None:
+    """Test async_setup_entry creates VM status and container memory sensors."""
+    from custom_components.unraid import UnraidRuntimeData
+    from custom_components.unraid.sensor import async_setup_entry
+
+    vm = VmDomain(id="vm:1", name="Ubuntu", state="RUNNING")
+    container = _make_docker_container("plex", "c1")
+
+    system_coordinator = MagicMock(spec=UnraidSystemCoordinator)
+    system_coordinator.data = make_system_data(vms=[vm], containers=[container])
+
+    storage_coordinator = MagicMock(spec=UnraidStorageCoordinator)
+    storage_coordinator.data = make_storage_data()
+
+    ws_manager = MagicMock()
+    ws_manager.container_stats.stats = {}
+
+    mock_entry = MagicMock()
+    mock_entry.data = {"host": "192.168.1.100"}
+    mock_entry.options = {}
+    mock_entry.runtime_data = UnraidRuntimeData(
+        api_client=MagicMock(),
+        system_coordinator=system_coordinator,
+        storage_coordinator=storage_coordinator,
+        infra_coordinator=MagicMock(),
+        server_info={"uuid": "test-uuid", "name": "tower"},
+        websocket_manager=ws_manager,
+    )
+
+    added_entities = []
+
+    def mock_add_entities(entities) -> None:
+        added_entities.extend(entities)
+
+    await async_setup_entry(hass, mock_entry, mock_add_entities)
+
+    entity_types = {type(e).__name__ for e in added_entities}
+    assert "VirtualMachineStatusSensor" in entity_types
+    assert "ContainerMemoryUsedSensor" in entity_types
+    assert "ContainerMemoryLimitSensor" in entity_types


### PR DESCRIPTION
## Description

This PR implements two requested feature improvements:

1. **Virtual Machine Status Sensors** (fixes #268):
   - Added dedicated sensor entities (`sensor.*_vm_status_*`) for virtual machines.
   - Reports VM domain state (`running`, `paused`, `shutoff`, `pmsuspended`, `crashed`, `idle`, `blocked`).
   - Exposes attributes: `vm_id` and `raw_state`.
   - Dynamically registered and pruned on VM changes.

2. **Docker Container Memory Used and Limit Sensors** (fixes #283):
   - Added numeric memory sensors (`sensor.*_container_*_memory_used` and `sensor.*_container_*_memory_limit`).
   - Disabled by default (`_attr_entity_registry_enabled_default = False`) to avoid cluttering the UI while allowing users to enable them for automations (e.g. restarting containers with memory leaks).
   - Parsed from container WebSocket stats supporting IEC and SI units into exact integer bytes, with suggested display unit `MB` (`UnitOfInformation.MEGABYTES`).
   - Returns `0` when container is stopped.

## Testing & Quality
- All unit tests pass: 1,126 passed with 96% overall code coverage (all modules >= 95%).
- Strict pyright type checking: 0 errors, 0 warnings.
- `./script/check` and `./script/lint` clean.
- Live tested in Home Assistant with WebSocket streaming verified.
- CHANGELOG.md updated under `[Unreleased]`.